### PR TITLE
快速安装页面的go get修改为go install

### DIFF
--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -20,8 +20,8 @@ This chapter gonna get you started with Kitex with a simple executable example.
 First of all, let's install compilers we gonna work with. 
 
 1. Ensure `GOPATH` environment variable is defined properly (for example `export GOPATH=~/go`), then add `$GOPATH/bin` to `PATH` environment variable (for example `export PATH=$GOPATH/bin:$PATH`). Make sure `GOPATH` is accessible.
-2. Install kitex: `go get github.com/cloudwego/kitex/tool/cmd/kitex@latest`
-3. Install thriftgo: `go get github.com/cloudwego/thriftgo@latest`
+2. Install kitex: `go install github.com/cloudwego/kitex/tool/cmd/kitex@latest`
+3. Install thriftgo: `go install github.com/cloudwego/thriftgo@latest`
 
 Now you can run `kitex --version` and `thriftgo --version`, and you can see some outputs just like below if you setup compilers successfully.
 

--- a/content/zh/docs/Getting started/_index.md
+++ b/content/zh/docs/Getting started/_index.md
@@ -21,8 +21,8 @@ description: >
 首先，我们需要安装使用本示例所需要的命令行代码生成工具：
 
 1. 确保 `GOPATH` 环境变量已经被正确地定义（例如 `export GOPATH=~/go`）并且将`$GOPATH/bin`添加到 `PATH` 环境变量之中（例如 `export PATH=$GOPATH/bin:$PATH`）；请勿将 `GOPATH` 设置为当前用户没有读写权限的目录
-2. 安装 kitex：`go get github.com/cloudwego/kitex/tool/cmd/kitex@latest`
-3. 安装 thriftgo：`go get github.com/cloudwego/thriftgo@latest`
+2. 安装 kitex：`go install github.com/cloudwego/kitex/tool/cmd/kitex@latest`
+3. 安装 thriftgo：`go install github.com/cloudwego/thriftgo@latest`
 
 安装成功后，执行 `kitex --version` 和 `thriftgo --version` 应该能够看到具体版本号的输出（版本号有差异，以 x.x.x 示例）：
 


### PR DESCRIPTION

Fixes #50 快速安装页面的go get修改为go install避免出现系统提示

```
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```
