### PR TITLE
chore: sorting releases by date

### DIFF
--- a/content/en/blog/releases/Kitex/release-v001.md
+++ b/content/en/blog/releases/Kitex/release-v001.md
@@ -2,7 +2,6 @@
 title: "Kitex Release v0.0.1"
 linkTitle: "Release v0.0.1"
 date: 2021-07-12
-weight: 1
 description: >
   
 ---

--- a/content/en/blog/releases/Kitex/release-v002.md
+++ b/content/en/blog/releases/Kitex/release-v002.md
@@ -2,7 +2,6 @@
 title: "Kitex Release v0.0.2"
 linkTitle: "Release v0.0.2"
 date: 2021-07-30
-weight: 2
 description: >
   
 ---

--- a/content/en/blog/releases/Kitex/release-v003.md
+++ b/content/en/blog/releases/Kitex/release-v003.md
@@ -2,7 +2,6 @@
 title: "Kitex Release v0.0.3"
 linkTitle: "Release v0.0.3"
 date: 2021-08-01
-weight: 3
 description: >
   
 ---

--- a/content/en/blog/releases/Kitex/release-v004.md
+++ b/content/en/blog/releases/Kitex/release-v004.md
@@ -2,7 +2,6 @@
 title: "Kitex Release v0.0.4"
 linkTitle: "Release v0.0.4"
 date: 2021-08-26
-weight: 4
 description: >
   
 ---

--- a/content/en/blog/releases/Kitex/release-v005.md
+++ b/content/en/blog/releases/Kitex/release-v005.md
@@ -2,7 +2,6 @@
 title: "Kitex Release v0.0.5"
 linkTitle: "Release v0.0.5"
 date: 2021-09-26
-weight: 5
 description: >
   
 ---

--- a/content/zh/blog/releases/Kitex/release-v001.md
+++ b/content/zh/blog/releases/Kitex/release-v001.md
@@ -2,7 +2,6 @@
 title: "Kitex v0.0.1 版本发布"
 linkTitle: "Release v0.0.1"
 date: 2021-07-12
-weight: 1
 description: >
   
 ---

--- a/content/zh/blog/releases/Kitex/release-v002.md
+++ b/content/zh/blog/releases/Kitex/release-v002.md
@@ -2,7 +2,6 @@
 title: "Kitex v0.0.2 版本发布"
 linkTitle: "Release v0.0.2"
 date: 2021-07-30
-weight: 2
 description: >
   
 ---

--- a/content/zh/blog/releases/Kitex/release-v003.md
+++ b/content/zh/blog/releases/Kitex/release-v003.md
@@ -2,7 +2,6 @@
 title: "Kitex v0.0.3 版本发布"
 linkTitle: "Release v0.0.3"
 date: 2021-08-01
-weight: 3
 description: >
   
 ---

--- a/content/zh/blog/releases/Kitex/release-v004.md
+++ b/content/zh/blog/releases/Kitex/release-v004.md
@@ -2,7 +2,6 @@
 title: "Kitex v0.0.4 版本发布"
 linkTitle: "Release v0.0.4"
 date: 2021-08-26
-weight: 4
 description: >
 ---
 

--- a/content/zh/blog/releases/Kitex/release-v005.md
+++ b/content/zh/blog/releases/Kitex/release-v005.md
@@ -2,7 +2,6 @@
 title: "Kitex v0.0.5 版本发布"
 linkTitle: "Release v0.0.5"
 date: 2021-09-26
-weight: 5
 description: >
   
 ---


### PR DESCRIPTION
sorting releases-section by date instead of weight
according to [hugo's doc](https://gohugo.io/templates/lists#default-weight--date--linktitle--filepath)


### before
![image](https://user-images.githubusercontent.com/8766820/138586095-f3e921e5-ebbb-4207-b6fd-ad13d372383f.png)

### after
![image](https://user-images.githubusercontent.com/8766820/138586083-14e69745-bbd9-4412-a383-e5c057d939de.png)
