### PR TITLE
fix: en docs typo fix for kitex

### DIFF
--- a/content/en/docs/kitex/Getting started/_index.md
+++ b/content/en/docs/kitex/Getting started/_index.md
@@ -193,8 +193,8 @@ for {
         }
         log.Println(resp)
         time.Sleep(time.Second)
-  			addReq := &api.AddRequest{First: 512, Second: 512}
-  			addResp, err := client.Add(context.Background(), addReq)
+        addReq := &api.AddRequest{First: 512, Second: 512}
+        addResp, err := client.Add(context.Background(), addReq)
         if err != nil {
                 log.Fatal(err)
         }

--- a/content/en/docs/kitex/Reference/exception.md
+++ b/content/en/docs/kitex/Reference/exception.md
@@ -85,7 +85,7 @@ These error is thrift Application Exception, usually these error will be wrapped
 
 | Code | Name                        | Meaning              |
 | ---- | --------------------------- | -------------------- |
-| 0    | UnknwonApplicationException | Unknown Error        |
+| 0    | UnknownApplicationException | Unknown Error        |
 | 1    | UnknownMethod               | Unknown Function     |
 | 2    | InValidMessageTypeException | Invalid Message Type |
 | 3    | WrongMethodName             | Wrong Method Name    |

--- a/content/en/docs/kitex/Tutorials/advanced-feature/generic_call.md
+++ b/content/en/docs/kitex/Tutorials/advanced-feature/generic_call.md
@@ -141,7 +141,7 @@ service BizService {
 
 - **Request**
 
-Type: *generic.HTTPReqeust
+Type: *generic.HTTPRequest
 
 - **Response**
 

--- a/content/en/docs/kitex/Tutorials/advanced-feature/metainfo.md
+++ b/content/en/docs/kitex/Tutorials/advanced-feature/metainfo.md
@@ -9,15 +9,15 @@ description: >
 
 As an RPC framework, Kitex services communicate with each other through protocols described by IDL (thrift, protobuf, etc.). The interface defined in an IDL determines the data structures that could be transmitted between the client and the server.
 
-However, in the production environment, we somehow may need to send special information to a remote server and that information is temporary or has an unstable format which can not be explictly defined in the IDL. Such a situation requests the framework to be capable of sending meta information.
+However, in the production environment, we somehow may need to send special information to a remote server and that information is temporary or has an unstable format which can not be explicitly defined in the IDL. Such a situation requests the framework to be capable of sending meta information.
 
 When the underlying transport protocol supports (such as TTHeader, HTTP), then Kitex can transmit meta information.
 
-To decouple with the underlying transport protocols, and interoperate with other frameworks, Kitex does not provide APIs to read or write meta information directly. Instead, it uses a stand-alone library [metainfo][metainfo] to support meta inforamtion transmitting.
+To decouple with the underlying transport protocols, and interoperate with other frameworks, Kitex does not provide APIs to read or write meta information directly. Instead, it uses a stand-alone library [metainfo][metainfo] to support meta information transmitting.
 
 ## Forward Meta Information Transmitting
 
-Pacakge [metainfo][metainfo] provides two kinds of API for sending meta information forward -- transient and persistent. The former is for ordinary needs of sending meta information; while the later is used when the meta information needs to be kept and sent to the next service and on, like a log ID or a dying tag. Of course, the persistent APIs works only when the next service and its successors all supports the meta information tarnsmitting convention.
+Package [metainfo][metainfo] provides two kinds of API for sending meta information forward -- transient and persistent. The former is for ordinary needs of sending meta information; while the later is used when the meta information needs to be kept and sent to the next service and on, like a log ID or a dying tag. Of course, the persistent APIs works only when the next service and its successors all supports the meta information tarnsmitting convention.
 
 A client side example:
 
@@ -27,7 +27,7 @@ import "github.com/bytedance/gopkg/cloud/metainfo"
 func main() {
     ...
     ctx := context.Background()
-    cli := myservice.MustNewCilent(...)
+    cli := myservice.MustNewClient(...)
     req := myservice.NewSomeRequest()
 
     ctx = metainfo.WithValue(ctx, "temp", "temp-value")       // attach the meta information to the context
@@ -46,7 +46,7 @@ import (
     "github.com/bytedance/gopkg/cloud/metainfo"
 )
 
-var cli2 = myservice2.MustNewCilent(...) // the client for next service
+var cli2 = myservice2.MustNewClient(...) // the client for next service
 
 func (MyServiceImpl) SomeMethod(ctx context.Context, req *SomeRequest) (res *SomeResponse, err error) {
     temp, ok1 := metainfo.GetValue(ctx, "temp")
@@ -77,10 +77,10 @@ import "github.com/bytedance/gopkg/cloud/metainfo"
 func main() {
     ...
     ctx := context.Background()
-    cli := myservice.MustNewCilent(...)
+    cli := myservice.MustNewClient(...)
     req := myservice.NewSomeRequest()
 
-    ctx = metainfo.WithBackwardValues(ctx) // mark the context to receive backward meta inforamtion
+    ctx = metainfo.WithBackwardValues(ctx) // mark the context to receive backward meta information
     resp, err := cli.SomeMethod(ctx, req)  // pass the context as an argument
 
     if err == nil {

--- a/content/en/docs/kitex/Tutorials/basic-feature/logging.md
+++ b/content/en/docs/kitex/Tutorials/basic-feature/logging.md
@@ -7,7 +7,7 @@ description: >
 
 ## pkg/klog
 
-Kitex defines serveral interfaces in the package `pkg/klog`: `Logger`, `CtxLoggerKey` and `FormatLogger`. And it provides a default logger that implements those interfaces and can be accessed by calling `klog.DefaultLogger()`.
+Kitex defines several interfaces in the package `pkg/klog`: `Logger`, `CtxLoggerKey` and `FormatLogger`. And it provides a default logger that implements those interfaces and can be accessed by calling `klog.DefaultLogger()`.
 
 There are global functions in the package `pkg/klog` that expose the ability of the default logger, like `klog.Info`, `klog.Errorf` and so on.
 

--- a/content/en/docs/kitex/Tutorials/framework-exten/registry.md
+++ b/content/en/docs/kitex/Tutorials/framework-exten/registry.md
@@ -49,7 +49,7 @@ Specify your own registration module and customized registration information thr
 
   ```go
   ebi := &rpcinfo.EndpointBasicInfo{
-  		ServiceName: 'yourSerivceName',
+  		ServiceName: 'yourServiceName',
   		Tags:        make(map[string]string),
   }
   ebi.Tags[idc] = "xxx"


### PR DESCRIPTION
Hi, recently I walked through the official docs of Kitex and found some typos. This PR fixed all of them.