### PR TITLE
[docs]: 完善一下网络库选择上的表达

### DIFF
--- a/content/zh/docs/hertz/tutorials/basic-feature/network-lib.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/network-lib.md
@@ -9,7 +9,7 @@ description: >
 Hertz 默认集成了 Netpoll 和 Golang 原生网络库 两个网络库，用户可以根据自己的场景选择合适的网络库以达到最佳性能。
 
 ## 使用方式
-对于 Server 来说，默认未使用 netpoll ，可以通过配置项进行更改：
+对于 Server 来说，windows默认未使用 netpoll ，非windows默认使用netpoll，可以通过配置项进行更改：
 
 ```go
 server.New(server.WithTransport(standard.NewTransporter))

--- a/content/zh/docs/hertz/tutorials/basic-feature/network-lib.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/network-lib.md
@@ -9,7 +9,7 @@ description: >
 Hertz 默认集成了 Netpoll 和 Golang 原生网络库 两个网络库，用户可以根据自己的场景选择合适的网络库以达到最佳性能。
 
 ## 使用方式
-对于 Server 来说，默认使用 netpoll ，可以通过配置项进行更改：
+对于 Server 来说，默认未使用 netpoll ，可以通过配置项进行更改：
 
 ```go
 server.New(server.WithTransport(standard.NewTransporter))


### PR DESCRIPTION
根据当前最新commit(a45cbc6c57edc9b07da9d1ae1d5e2a4861b874d6)源码
New调用的pkg/route/engine.go中NewEngine指定transport为defaultTransporter(opt)
defaultTransporter是常量standard.NewTransporter 固默认未使用netpoll
当非windows平台编译时会修改参数为defaultTransporter = netpoll.NewTransporter 此时使用netpoll

粗略看了一下源码 如有理解错误请指出