### PR TITLE
docs: restructure /docs/hertz/reference/json.md

### DIFF
--- a/content/en/docs/hertz/reference/json.md
+++ b/content/en/docs/hertz/reference/json.md
@@ -18,10 +18,10 @@ Sonic automatically fallback to golang's `encoding/json` library when the above 
 
 ## Compatibility With `encoding/json`
 
-Currently, Hertz uses the default configuration for Sonic (i.e.`sonic.ConfigDefault`, which behaves different from JSON `encoding/json`.
+Currently, Hertz uses the default configuration for Sonic (i.e.`sonic.ConfigDefault`), which behaves different from JSON `encoding/json`.
 Specifically, by default, Sonic are configured to:
 - disable html escape: Sonic will not escape HTML's special characters
-- disable key-sort by default: Sonic will not sort json based on keys
+- disable key-sort by default: Sonic will not sort json in lexicographical order
 
 To find more about the compatibility with `encoding/json`, you may want to see [sonic#Compatibility](https://github.com/bytedance/sonic#compatibility).
 You may change Sonic's behavior (e.g. behaving exactly the same way as `encoding/json`) by calling `ResetJSONMarshaler` for render.
@@ -55,15 +55,10 @@ func main() {
 
 ### Compilation Error on Mac M1
 #### Unsupported CPU, maybe it’s too old to run Sonic
-In most cases, this is because the go binary and/or build configuration is incompatible with Sonic.
-
-##### Go binary is not built for ARM64
-Please use a go binary compiled for ARM64. You may encounter issues on go1.16 as compiler incorrectly links x86 files due to bugs.
+In most cases, this is because the go binary and/or build configuration is not consistent with ARM arch.
+- Go binary is not built for ARM64. Please use a go binary compiled for ARM64. You may encounter issues on go1.16 as compiler incorrectly links x86 files due to official bugs.
 Therefore, go1.17 or above is highly recommended.
-##### GOARCH is set to amd64 `i.e. GOARCH=amd64`
-You can either remove the flag or set its value to `arm64`.
-##### Ran Binaries compiled in an x86 environment with a translator
-This is not supported yet.
-
-### Build constraints exclude all Go files in xxx
+- GOARCH is set to amd64 `i.e. GOARCH=amd64`. You can either remove the flag or set its value to `arm64`.
+- Running go binary compiled for x86 with a translator (e.g. Rosetta). This is not supported yet.
+####Build constraints exclude all Go files in xxx
 This is mostly because Sonic does not work on your go version. See [sonic#Requirement](https://github.com/bytedance/sonic#requirement) for a list of supported go versions.

--- a/content/zh/docs/hertz/reference/json.md
+++ b/content/zh/docs/hertz/reference/json.md
@@ -58,14 +58,10 @@ render.ResetJSONMarshal(json.Marshal)
 ```
 ## 常见问题
 ### Mac M1 上编译报错
-
 #### Unsupported CPU, maybe it's too old to run Sonic
-一般为是因为 Go 镜像版本或构建参数和 Sonic 不兼容
-#### 安装了非 arm 版本的 go 镜像
-请安装 arm 版本 Go 镜像（go1.16某些 arm 镜像存在 bug 会导致 link 错误的 x86 文件，推荐 go1.17 以上版本）
-#### 设置了 GOARCH=amd64
-请去除该参数或设置为 arm64
-#### 使用了转译器运行 x86 环境下编译出来的程序
-目前不支持这种使用方式
+- 一般为是因为 Go 镜像版本或构建参数和 Sonic 不兼容
+- 安装了非 arm 版本的 go 镜像。请安装 arm 版本 Go 镜像（go1.16某些 arm 镜像存在 bug 会导致 link 错误的 x86 文件，推荐 go1.17 以上版本）
+- 设置了 GOARCH=amd64。请去除该参数或设置为 arm64
+- 使用了转译器运行 x86 环境下编译出来的程序。目前不支持这种使用方式
 ###Build constraints exclude all Go files in xxx
 一般是 Go 版本导致的问题，sonic 目前支持的版本见 [sonic#Requirement](https://github.com/bytedance/sonic#requirement)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
This PR changed the layout of json.md in both zh and en, specificlly it introduces sonic first, then inform how sonic differs from `encoding/json` in terms of behaviour. Lastly, it covers how to BYO json marshall implemenation. I believe it will help user to navigate and find what they need easier. 
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: restructure json.md
zh: 调整 json.md 结构

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/cloudwego/cloudwego.github.io/issues/234