### PR TITLE
docs: translate basic-feature/transport_protocol/

### DIFF
--- a/content/en/docs/kitex/Tutorials/basic-feature/transport_protocol.md
+++ b/content/en/docs/kitex/Tutorials/basic-feature/transport_protocol.md
@@ -5,4 +5,68 @@ weight: 3
 description: >
 ---
 
-Translation TODO
+An RPC protocol generally includes a transport protocol in the application layer and a message protocol that tells how to access the payload. Transport protocols come with rich mechanisms that let you deal with additional metadata, which can be helpful for service governance. And Kitex allows you to read or write metadata through a protocol based on MetaHandler. The capability of carrying metadata enables us to track requests in their entirety as it travels across services of a distributed system, and thus makes transport protocol indispensable in Microservices.
+
+Kitex already supports TTHeader and HTTP2. Available options for transport protocol are TTHeader、GRPC、Framed、TTHeaderFramed、PurePayload.
+
+Some clarifications:
+
+- Kitex supports Protobuf in two ways: Kitex Protobuf and gRPC. We include gRPC as a transport protocol to make it easy to distinguish. Internally, Kitex will identify the protocol based on whether gRPC was configured.
+- Framed is not technically a transport protocol. It was just there for marking the extra 4 bytes header in Payload Size. But the message protocol does not enforce the need for Framed Header. For instance, PurePayload doesn't have any Header. Therefore, we also include Framed as an option for the transport protocol.
+- Framed and TTHeader could be used together, which leads to TTHeaderFramed.
+
+Here are the available combination options of transport protocols and message protocols in Kitex:
+
+- Thrift: **TTHeader**(recommend), Framed, TTHeaderFramed
+- KitexProtobuf: **TTHeader**(recommend), Framed, TTHeaderFramed
+- gRPC: HTTP2
+
+If you want to use custom implementations for the message or transport protocol, you can find help here [Extension of Codec](https://www.cloudwego.io/docs/kitex/tutorials/framework-exten/codec/).
+
+# Configuration
+
+You can configure the transport protocol when initializing the client:
+```go
+// client option
+client.WithTransportProtocol(transport.XXX)
+```
+
+Kitex Server supports protocol detection for all supported protocols and doesn't require explicit configuration.
+
+# Usage
+
+## Thrift + TTHeader
+
+```go
+// client side
+var opts []client.Option
+opts = append(opts, client.WithTransportProtocol(transport.TTHeader))
+// use TTHeader meta handler. >= v0.3.4 ClientTTHeaderHandler is added by default, don't need to do setup
+opts = append(opts, client.WithMetaHandler(transmeta.ClientTTHeaderHandler))
+cli, err := xxxservice.NewClient(targetService, opts...)
+
+// server side no need to config transport protocol
+var opts []server.Option
+// use TTHeader meta handler. >= v0.3.4 ServerTTHeaderHandler is added by default, don't need to do setup
+opts = append(opts, server.WithMetaHandler(transmeta.ServerTTHeaderHandler))
+cli, err := xxxservice.NewServer(handler, opts...)
+```
+
+## gRPC
+
+```go
+// client side
+var opts []client.Option
+opts = append(opts, client.WithTransportProtocol(transport.GRPC))
+// use HTTP2 meta handler. >= v0.3.4 ClientHTTP2Handler is added by default, don't need to do setup
+opts = append(opts, client.WithMetaHandler(transmeta.ClientHTTP2Handler))
+cli, err := xxxservice.NewClient(targetService, opts...)
+
+
+// server side no need to config transport protocol
+var opts []server.Option
+// use HTTP2 meta handler. >= v0.3.4 ServerHTTP2Handler is added by default, don't need to do setup
+opts = append(opts, server.WithMetaHandler(transmeta.ServerHTTP2Handler))
+cli, err := xxxservice.NewServer(handler, opts...)
+
+```

--- a/content/zh/docs/kitex/Tutorials/basic-feature/transport_protocol.md
+++ b/content/zh/docs/kitex/Tutorials/basic-feature/transport_protocol.md
@@ -7,7 +7,13 @@ description: >
 
 通常 RPC 协议中包含 RPC 消息协议和应用层传输协议，RPC 消息协议看做是传输消息的 Payload，传输协议额外传递一些元信息通常会用于服务治理，框架的 MetaHandler 也是和传输协议搭配使用。在微服务场景下，传输协议起到了重要的作用，如链路跟踪的透传信息通常由传输协议进行链路传递。
 
-Kitex 目前支持两种传输协议：TTHeader、HTTP2，但实际提供配置的 Transport Protocol 是：TTHeader、GRPC、Framed、TTHeaderFramed、PurePayload。这里做一些说明：因为 Kitex 对 Protobuf 的支持有 Kitex Protobuf 和 gRPC，为方便区分将 gRPC 作为传输协议的分类，框架会根据是否有配置 gRPC 决定使用哪个协议；Framed 严格意义上并不是传输协议，只是标记 Payload Size 额外增加的 4 字节头，但消息协议对是否有 Framed 头并不是强制的，PurePayload 即没有任何头部的，所以将 Framed 也作为传输协议的分类；同时 Framed 和 TTHeader 也可以结合使用，所以有 TTHeaderFramed 。
+Kitex 目前支持两种传输协议：TTHeader、HTTP2，但实际提供配置的 Transport Protocol 是：TTHeader、GRPC、Framed、TTHeaderFramed、PurePayload。
+
+这里做一些说明：
+
+- 因为 Kitex 对 Protobuf 的支持有 Kitex Protobuf 和 gRPC，为方便区分将 gRPC 作为传输协议的分类，框架会根据是否有配置 gRPC 决定使用哪个协议；
+- Framed 严格意义上并不是传输协议，只是标记 Payload Size 额外增加的 4 字节头，但消息协议对是否有 Framed 头并不是强制的，PurePayload 即没有任何头部的，所以将 Framed 也作为传输协议的分类；
+- Framed 和 TTHeader 也可以结合使用，所以有 TTHeaderFramed 。
 
 
 消息协议可选的传输协议组合如下：


### PR DESCRIPTION
#### What type of PR is this?

docs: translate basic-feature/transport_protocol chapter of Kitex from Chinese to English.

#### What this PR does / why we need it (en: English/zh: Chinese):
en: Provides the documentation of transport protocols in English.
zh: 补充传输协议说明文档

relevant issue: [Kitex 568](https://github.com/cloudwego/kitex/issues/568)