### PR TITLE
docs(q1_gat.md):补充文档最后章节缺漏的修饰词

### DIFF
--- a/content/zh/docs/motore/faq/q1_gat.md
+++ b/content/zh/docs/motore/faq/q1_gat.md
@@ -122,7 +122,7 @@ impl<Req, S> Service<Req> for LogService<S> {
 fn call<'cx, 's>(&'s mut self, cx: &'cx mut Context, req: Request) -> Future<'cx>;
 ```
 
-那么我们该怎么约束的 `Future` 的 lifetime 为 `'cx` 呢
+那么我们该怎么约束返回的 `Future` 的 lifetime 为 `'cx` 呢
 1. 使用 `Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + 'cx>>`
 2. GAT
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
在 [使用 GAT，解决了什么问题？](https://www.cloudwego.io/zh/docs/motore/faq/q1_gat/) 的最后一节中，有段话描述如下：    
```
那么我们该怎么约束的 Future 的 lifetime 为 'cx 呢
```
其中**怎么约束的 Future 的 lifetime**部分缺少修饰词，结合上下文，应添加改为：
```
那么我们该怎么约束返回的 Future 的 lifetime 为 'cx 呢
```

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: 
zh:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
