### PR TITLE
docs: corrected kitex registry example symbols

### DIFF
--- a/content/en/docs/kitex/Tutorials/framework-exten/registry.md
+++ b/content/en/docs/kitex/Tutorials/framework-exten/registry.md
@@ -49,28 +49,28 @@ Specify your own registration module and customized registration information thr
 
   ```go
   ebi := &rpcinfo.EndpointBasicInfo{
-  		ServiceName: 'yourServiceName',
+  		ServiceName: "yourServiceName",
   		Tags:        make(map[string]string),
   }
   ebi.Tags[idc] = "xxx"
-  
+
   svr := xxxservice.NewServer(handler, server.WithServerBasicInfo(ebi))
   ```
 
 - Specify Custom Registion module
-  
+
   option: `WithRegistry`
-  
+
   ```go
   svr := xxxservice.NewServer(handler, server.WithServerBasicInfo(ebi), server.WithRegistry(yourRegistry))
   ```
-  
-- Custom RegistryInfo 
-  
+
+- Custom RegistryInfo
+
   Kitex sets ServiceName, Addr and PayloadCodec by default. If other registration information is required, you need to inject it by yourself. option: `WithRegistryInfo`.
-  
+
   ```go
   svr := xxxservice.NewServer(handler, server.WithRegistry(yourRegistry), server.WithRegistryInfo(yourRegistryInfo))
   ```
-  
-  
+
+

--- a/content/zh/docs/kitex/Tutorials/framework-exten/registry.md
+++ b/content/zh/docs/kitex/Tutorials/framework-exten/registry.md
@@ -49,7 +49,7 @@ type Info struct {
 
   ```go
   ebi := &rpcinfo.EndpointBasicInfo{
-      ServiceName: 'yourServiceName',
+      ServiceName: "yourServiceName",
       Tags:        make(map[string]string),
   }
   ebi.Tags[idc] = "xxx"


### PR DESCRIPTION
#### What type of PR is this?

docs: corrected kitex registry example symbols

#### What this PR does / why we need it (en: English/zh: Chinese):

en: docs: corrected kitex registry example symbols 
zh: 修正kitex服务注册示例的代码单引号为双引号

#### Which issue(s) this PR fixes:

