### PR TITLE
docs: add another example for ut

### DIFF
--- a/content/en/docs/hertz/tutorials/basic-feature/unit-test.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/unit-test.md
@@ -45,7 +45,7 @@ func TestPerformRequest(t *testing.T) {
 
 ## Another Example
 
-Assume you have a handler go file and a function called ```Ping()```
+Assume you have a handler go file and a function called `Ping()`
 ```go
 
 package handler

--- a/content/en/docs/hertz/tutorials/basic-feature/unit-test.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/unit-test.md
@@ -88,6 +88,6 @@ func TestPerformRequest(t *testing.T) {
 	assert.DeepEqual(t, "{\"message\":\"pong\"}", string(resp.Body()))
 }
 ```
-Every time you change the `Ping()` behavior, you don't need to copy ti to test file again and again.
+Every time you change the `Ping()` behavior, you don't need to copy it to test file again and again.
 
 For more examples, refer to the unit test file in [pkg/common/ut](https://github.com/cloudwego/hertz/tree/main/pkg/common/ut).

--- a/content/en/docs/hertz/tutorials/basic-feature/unit-test.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/unit-test.md
@@ -65,7 +65,7 @@ func Ping(ctx context.Context, c *app.RequestContext) {
 }
 ```
 
-Now you can do some unit test directly to the ```Ping()``` function.
+Now you can do some unit test directly to the `Ping()` function.
 ```go
 package handler
 
@@ -88,6 +88,6 @@ func TestPerformRequest(t *testing.T) {
 	assert.DeepEqual(t, "{\"message\":\"pong\"}", string(resp.Body()))
 }
 ```
-Every time you change the ```Ping()``` behavior, you don't need to copy ti to test file again and again.
+Every time you change the `Ping()` behavior, you don't need to copy ti to test file again and again.
 
 For more examples, refer to the unit test file in [pkg/common/ut](https://github.com/cloudwego/hertz/tree/main/pkg/common/ut).

--- a/content/en/docs/hertz/tutorials/basic-feature/unit-test.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/unit-test.md
@@ -43,4 +43,51 @@ func TestPerformRequest(t *testing.T) {
 }
 ```
 
+## Another Example
+
+Assume you have a handler go file and a function called ```Ping()```
+```go
+
+package handler
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/common/utils"
+)
+
+// Ping .
+func Ping(ctx context.Context, c *app.RequestContext) {
+	c.JSON(200, utils.H{
+		"message": "pong",
+	})
+}
+```
+
+Now you can do some unit test directly to the ```Ping()``` function.
+```go
+package handler
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
+	"github.com/cloudwego/hertz/pkg/common/ut"
+)
+
+func TestPerformRequest(t *testing.T) {
+	h := server.Default()
+	h.GET("/ping", Ping)
+	w := ut.PerformRequest(h.Engine, "GET", "/ping", &ut.Body{bytes.NewBufferString("1"), 1},
+		ut.Header{"Connection", "close"})
+	resp := w.Result()
+	assert.DeepEqual(t, 201, resp.StatusCode())
+	assert.DeepEqual(t, "{\"message\":\"pong\"}", string(resp.Body()))
+}
+```
+Every time you change the ```Ping()``` behavior, you don't need to copy ti to test file again and again.
+
 For more examples, refer to the unit test file in [pkg/common/ut](https://github.com/cloudwego/hertz/tree/main/pkg/common/ut).

--- a/content/en/docs/hertz/tutorials/basic-feature/unit-test.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/unit-test.md
@@ -43,7 +43,7 @@ func TestPerformRequest(t *testing.T) {
 }
 ```
 
-## Another Example
+## Work with biz handler
 
 Assume you have a handler go file and a function called `Ping()`
 ```go

--- a/content/zh/docs/hertz/tutorials/basic-feature/unit-test.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/unit-test.md
@@ -43,7 +43,7 @@ func TestPerformRequest(t *testing.T) {
 }
 ```
 
-## 另一个例子
+## 与业务handler配合使用
 
 假如已经创建了handler以及一个函数`Ping()`
 ```go

--- a/content/zh/docs/hertz/tutorials/basic-feature/unit-test.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/unit-test.md
@@ -43,4 +43,51 @@ func TestPerformRequest(t *testing.T) {
 }
 ```
 
+## 另一个例子
+
+假如已经创建了handler以及一个函数```Ping()```
+```go
+
+package handler
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/common/utils"
+)
+
+// Ping .
+func Ping(ctx context.Context, c *app.RequestContext) {
+	c.JSON(200, utils.H{
+		"message": "pong",
+	})
+}
+```
+
+可以在单元测试中直接对```ping()```函数进行测试
+```go
+package handler
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
+	"github.com/cloudwego/hertz/pkg/common/ut"
+)
+
+func TestPerformRequest(t *testing.T) {
+	h := server.Default()
+	h.GET("/ping", Ping)
+	w := ut.PerformRequest(h.Engine, "GET", "/ping", &ut.Body{bytes.NewBufferString("1"), 1},
+		ut.Header{"Connection", "close"})
+	resp := w.Result()
+	assert.DeepEqual(t, 201, resp.StatusCode())
+	assert.DeepEqual(t, "{\"message\":\"pong\"}", string(resp.Body()))
+}
+```
+之后对```Ping()```函数进行修改，单元测试文件不需要复制相同的业务逻辑。
+
 更多 examples 参考 [pkg/common/ut](https://github.com/cloudwego/hertz/tree/main/pkg/common/ut) 中的单测文件。

--- a/content/zh/docs/hertz/tutorials/basic-feature/unit-test.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/unit-test.md
@@ -45,7 +45,7 @@ func TestPerformRequest(t *testing.T) {
 
 ## 另一个例子
 
-假如已经创建了handler以及一个函数```Ping()```
+假如已经创建了handler以及一个函数`Ping()`
 ```go
 
 package handler
@@ -65,7 +65,7 @@ func Ping(ctx context.Context, c *app.RequestContext) {
 }
 ```
 
-可以在单元测试中直接对```ping()```函数进行测试
+可以在单元测试中直接对`ping()`函数进行测试
 ```go
 package handler
 
@@ -88,6 +88,6 @@ func TestPerformRequest(t *testing.T) {
 	assert.DeepEqual(t, "{\"message\":\"pong\"}", string(resp.Body()))
 }
 ```
-之后对```Ping()```函数进行修改，单元测试文件不需要复制相同的业务逻辑。
+之后对`Ping()`函数进行修改，单元测试文件不需要复制相同的业务逻辑。
 
 更多 examples 参考 [pkg/common/ut](https://github.com/cloudwego/hertz/tree/main/pkg/common/ut) 中的单测文件。


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
docs: add another example for UT, to make it more simply.

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

en: This dock PR comes from Hertz Framework PR https://github.com/cloudwego/hertz/pull/333. Add more examples for new users to write their unit tests more efficiently and more simple. Which is useful for the project created by `hertz new` template.
zh: 来自于 Hertz框架的PR This dock PR comes from Hertz Framework PR https://github.com/cloudwego/hertz/pull/333。 增加更贴近实际使用场景的单测样例，让新手可以更快开发。在使用了`hertz new`命令创建的示例模板中使用更快捷。

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
