### PR TITLE
docs: add version information for hertz retry

### DIFF
--- a/content/en/docs/hertz/reference/config.md
+++ b/content/en/docs/hertz/reference/config.md
@@ -78,7 +78,7 @@ func main() {
 | WithMaxConnDuration | time.Duration | Set the maximum keep-alive time of the connection, when the timeout expired, the connection will be closed after the current request is completed. Default: infinite. |
 | WithMaxConnWaitTimeout | time.Duration | Set the maximum time to wait for an idle connection. Default: no wait. |
 | WithKeepAlive | bool | Whether to use persistent connection. Default: true. |
-| WithRetryConfig | ...retry.Option | Set the retry config of client. Hertz version >= v0.4.0 |
+| WithRetryConfig | ...retry.Option | Set the retry config of client. Hertz version >= v0.4.0. |
 | ~~WithMaxIdempotentCallAttempts~~ | int | Set the maximum number of calls. If a call fails, it will be retried. Default: 1 (That is no retry). v0.4.0 is obsolete. Only available before v0.4.0. It is recommended to upgrade Hertz version >= v0.4.0 and use WithRetryConfig instead. |
 | WithClientReadTimeout | time.Duration | Set the maximum time to read the response. Default: infinite. |
 | WithTLSConfig | *tls.Config | Set the client's TLS config for mutual TLS authentication. |

--- a/content/en/docs/hertz/reference/config.md
+++ b/content/en/docs/hertz/reference/config.md
@@ -78,7 +78,8 @@ func main() {
 | WithMaxConnDuration | time.Duration | Set the maximum keep-alive time of the connection, when the timeout expired, the connection will be closed after the current request is completed. Default: infinite. |
 | WithMaxConnWaitTimeout | time.Duration | Set the maximum time to wait for an idle connection. Default: no wait. |
 | WithKeepAlive | bool | Whether to use persistent connection. Default: true. |
-| WithRetryConfig | ...retry.Option | Set the retry config of client. |
+| WithRetryConfig | ...retry.Option | Set the retry config of client. Hertz version >= v0.4.0 |
+| ~~WithMaxIdempotentCallAttempts~~ | int | Set the maximum number of calls. If a call fails, it will be retried. Default: 1 (That is no retry). v0.4.0 is obsolete. Only available before v0.4.0. It is recommended to upgrade Hertz version >= v0.4.0 and use WithRetryConfig instead. |
 | WithClientReadTimeout | time.Duration | Set the maximum time to read the response. Default: infinite. |
 | WithTLSConfig | *tls.Config | Set the client's TLS config for mutual TLS authentication. |
 | WithDialer | network.Dialer | Set the network library used by the client. Default: netpoll. |

--- a/content/en/docs/hertz/tutorials/basic-feature/retry.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/retry.md
@@ -10,7 +10,7 @@ Hertz provides users with customized retry logic,Let's take a look at how to use
 
 ## Retry times and delay policy configuration
 
-First create a Client, and use the configuration item `WithRetryConfig()` to configure the Retry related logic. (This section mainly configures the times of retry and the delay policy )
+First create a Client, and use the configuration item `WithRetryConfig()` to configure the Retry related logic. (This section mainly configures the times of retry and the delay policy)
 
 ```go
 package main

--- a/content/en/docs/hertz/tutorials/basic-feature/retry.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/retry.md
@@ -6,11 +6,11 @@ description: >
 
 ---
 
-Hertz provides users with customized retry logic,Let's take a look at how to use Client Retry(This section mainly configures the times of retry and the delay policy )
+Hertz provides users with customized retry logic,Let's take a look at how to use Client Retry. **Note: Hertz version >= v0.4.0**
 
 ## Retry times and delay policy configuration
 
-First create a Client, and use the configuration item `WithRetryConfig()` to configure the Retry related logic
+First create a Client, and use the configuration item `WithRetryConfig()` to configure the Retry related logic. (This section mainly configures the times of retry and the delay policy )
 
 ```go
 package main

--- a/content/zh/docs/hertz/reference/config.md
+++ b/content/zh/docs/hertz/reference/config.md
@@ -77,7 +77,8 @@ func main() {
 | WithMaxConnDuration | time.Duration | 设置连接存活的最大时长，超过这个时间的连接在完成当前请求后会被关闭，默认无限长 |
 | WithMaxConnWaitTimeout | time.Duration | 设置等待空闲连接的最大时间，默认不等待 |
 | WithKeepAlive | bool | 是否使用长连接，默认开启 |
-| WithRetryConfig | ...retry.Option | 设置 client 的 retry config |
+| WithRetryConfig | ...retry.Option | 设置 client 的 retry config。Hertz 版本需 >= v0.4.0|
+| ~~WithMaxIdempotentCallAttempts~~ | int | 设置最大调用次数，调用失败则会重试。默认1次即不重试。v0.4.0版本废止，该版本之前可用，建议升级 Hertz 版本 >= v0.4.0 并使用 WithRetryConfig 替代 |
 | WithClientReadTimeout | time.Duration | 设置读取 response 的最长时间，默认无限长 |
 | WithTLSConfig | *tls.Config | 双向 TLS 认证时，设置 client 的 TLS config |
 | WithDialer | network.Dialer | 设置 client 使用的网络库，默认 netpoll |

--- a/content/zh/docs/hertz/tutorials/basic-feature/retry.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/retry.md
@@ -6,7 +6,7 @@ description: >
 
 ---
 
-Hertz 为用户提供了自定义的重试逻辑，下面来看一下 Client 的 Retry 使用方法
+Hertz 为用户提供了自定义的重试逻辑，下面来看一下 Client 的 Retry 使用方法。**注意：Hertz 版本 >= v0.4.0**
 
 ## Retry 次数及延迟策略配置
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
docs 
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: Add version information for hertz retry. Optimize the English document because there was a sentence in the wrong place before
zh: 增加 hertz retry 的版本信息，优化英文文档，以前有句话位置有误

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
