### PR TITLE
docs: Fix an error in the routing document

### DIFF
--- a/content/en/docs/hertz/tutorials/basic-feature/route.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/route.md
@@ -61,7 +61,7 @@ func main(){
 	h.Any("/ping_any", func(ctx context.Context, c *app.RequestContext) {
 		c.String(consts.StatusOK, "any")
 	})
-	h.Handle("Load","/load", func(ctx context.Context, c *app.RequestContext) {
+	h.Handle("LOAD","/load", func(ctx context.Context, c *app.RequestContext) {
 		c.String(consts.StatusOK, "load")
 	})
 	h.Spin()

--- a/content/zh/docs/hertz/tutorials/basic-feature/route.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/route.md
@@ -64,7 +64,7 @@ func main(){
 	h.Any("/ping_any", func(ctx context.Context, c *app.RequestContext) {
 		c.String(consts.StatusOK, "any")
 	})
-	h.Handle("Load","/load", func(ctx context.Context, c *app.RequestContext) {
+	h.Handle("LOAD","/load", func(ctx context.Context, c *app.RequestContext) {
 		c.String(consts.StatusOK, "load")
 	})
 	h.Spin()


### PR DESCRIPTION
#### What type of PR is this?

docs

#### What this PR does / why we need it (en: English/zh: Chinese):
en:  Fix an error in the routing document, httpMethod in h.Handle() must be all capitalized
zh:  修改了路由文档中的一处错误，  h.Handle()  方法下的 httpMethod 参数必须全为大写



