### PR TITLE
docs: add file type tags for better display of docs

### DIFF
--- a/content/en/docs/hertz/tutorials/toolkit/template.md
+++ b/content/en/docs/hertz/tutorials/toolkit/template.md
@@ -40,7 +40,7 @@ The so-called layout template refers to the structure of the entire project. The
 
 ## IDL
 
-```
+```thrift
 // hello.thrift
 namespace go hello.example
 
@@ -60,7 +60,7 @@ service HelloService {
 
 ## Command
 
-```
+```shell
 hz new --mod=github.com/hertz/hello --idl=./hertzDemo/hello.thrift --customize_layout=template/layout.yaml:template/data.json
 ```
 
@@ -68,7 +68,7 @@ hz new --mod=github.com/hertz/hello --idl=./hertzDemo/hello.thrift --customize_l
 
 > Note: The following bodies are all go templates
 
-```
+```yaml
 layouts:
   # The directory of the generated handler will only be generated if there are files in the directory
   - path: biz/handler/
@@ -220,7 +220,7 @@ layouts:
 When a custom template and render data are specified, the options specified on the command line will not be used as render data, so the render data in the template needs to be defined by the user.
 
 Hz uses "json" to specify render data, as described below
-```
+```json5
 {
   // global render parameters
   "*": {
@@ -248,8 +248,8 @@ Assuming that the user only wants "main.go" and "go.mod" files, then we modify t
 
 ### template:
 
-```
-// layout.yaml
+```yaml
+# layout.yaml
 layouts:
   # project main file
   - path: main.go
@@ -308,7 +308,7 @@ layouts:
 
 ### render data:
 
-```
+```json5
 {
   "*": {
     "GoModule": "github.com/hertz/hello",
@@ -321,7 +321,7 @@ layouts:
 }
 ```
 Command:
-```
+```shell
 hz new --mod=github.com/hertz/hello --idl=./hertzDemo/hello.thrift --customize_layout=template/layout.yaml:template/data.json
 ```
 
@@ -339,7 +339,7 @@ hz new --mod=github.com/hertz/hello --idl=./hertzDemo/hello.thrift --customize_l
 
 ## Command
 
-```
+```shell
 # After that, the package template rendering data will be provided, so the form of "k-v" is retained when entering the command, and ":" needs to be added after customize_package.
 hz new --mod=github.com/hertz/hello --handler_dir=handler_test --idl=hertzDemo/hello.thrift --customize_package=template/package.yaml:
 ```
@@ -348,7 +348,7 @@ hz new --mod=github.com/hertz/hello --handler_dir=handler_test --idl=hertzDemo/h
 
 Note: Custom package templates do not provide the ability to render data.
 
-```
+```yaml
 layouts:
   # Path only represents handler.go template, the specific handler path is determined by the default path and handler_dir
   - path: handler.go
@@ -559,7 +559,7 @@ Here is an example of a simple custom handler template, adding some comments to 
 
 ### template:
 
-```
+```yaml
 layouts:
   # Path only represents handler.go template, the specific handler path is determined by the default path and handler_dir
   - path: handler.go
@@ -759,13 +759,13 @@ layouts:
 
 ```
 Command:
-```
+```shell
 # After that, the package template rendering data will be provided, so the form of "k-v" is retained when entering the command, and ":" needs to be added after customize_package.
 hz new --mod=github.com/hertz/hello --handler_dir=handler_test --idl=hertzDemo/hello.thrift --customize_package=template/package.yaml:
 ```
 
 The handler is generated as follows:
-```
+```go
 // this is my custom handler.
 
 package example

--- a/content/zh/docs/hertz/tutorials/toolkit/template.md
+++ b/content/zh/docs/hertz/tutorials/toolkit/template.md
@@ -40,7 +40,7 @@ hz 利用了 go template 支持以 "yaml" 的格式定义模板，并使用 "jso
 
 ## IDL
 
-```
+```thrift
 // hello.thrift
 namespace go hello.example
 
@@ -60,7 +60,7 @@ service HelloService {
 
 ## 命令
 
-```
+```shell
 hz new --mod=github.com/hertz/hello --idl=./hertzDemo/hello.thrift --customize_layout=template/layout.yaml:template/data.json
 ```
 
@@ -68,7 +68,7 @@ hz new --mod=github.com/hertz/hello --idl=./hertzDemo/hello.thrift --customize_l
 
 > 注：以下的 body 均为 go template
 
-```
+```yaml
 layouts:
   # 生成的 handler 的目录，只有目录下有文件才会生成
   - path: biz/handler/
@@ -221,7 +221,7 @@ layouts:
 
 hz 使用了"json"来指定渲染数据，下面进行介绍
 
-```
+```json5
 {
   // 全局的渲染参数
   "*": {
@@ -249,7 +249,7 @@ hz 使用了"json"来指定渲染数据，下面进行介绍
 
 ### template:
 
-```
+```yaml
 // layout.yaml
 layouts:
   # 项目 main 文件，
@@ -309,7 +309,7 @@ layouts:
 
 ### render data:
 
-```
+```json
 {
   "*": {
     "GoModule": "github.com/hertz/hello",
@@ -322,7 +322,7 @@ layouts:
 }
 ```
 命令：
-```
+```shell
 hz new --mod=github.com/hertz/hello --idl=./hertzDemo/hello.thrift --customize_layout=template/layout.yaml:template/data.json
 ```
 
@@ -340,7 +340,7 @@ hz new --mod=github.com/hertz/hello --idl=./hertzDemo/hello.thrift --customize_l
 
 ## 命令
 
-```
+```shell
 # 之后会提供 package 模板渲染数据，所以输入命令的时候先保留了"k-v"的形式，customize_package 后需要加":"
 hz new --mod=github.com/hertz/hello --handler_dir=handler_test --idl=hertzDemo/hello.thrift --customize_package=template/package.yaml:
 ```
@@ -349,7 +349,7 @@ hz new --mod=github.com/hertz/hello --handler_dir=handler_test --idl=hertzDemo/h
 
 注意：自定义 package 模板没有提供渲染数据的功能，这里主要是因为这些渲染数据是 hz 工具解析生成的，所以暂时不提供自己写渲染数据的功能。可以修改下模板里面与渲染数据无关的部分，以满足自身需求。
 
-```
+```yaml
 # 以下数据都是 yaml marshal 得到的，所以可能看起来比较乱
 layouts:
   # path只表示handler.go的模板，具体的handler路径由默认路径和handler_dir决定
@@ -561,7 +561,7 @@ layouts:
 
 ### template:
 
-```
+```yaml
 # 以下数据都是 yaml marshal 得到的，所以可能看起来比较乱
 layouts:
   # path只表示handler.go的模板，具体的handler路径由默认路径和handler_dir决定
@@ -761,13 +761,13 @@ layouts:
       }
 ```
 命令：
-```
+```shell
 # 之后会提供 package 模板渲染数据，所以输入命令的时候先保留了"k-v"的形式，customize_package 后需要加":"
 hz new --mod=github.com/hertz/hello --handler_dir=handler_test --idl=hertzDemo/hello.thrift --customize_package=template/package.yaml:
 ```
 
 生成handler如下：
-```
+```go
 // this is my custom handler.
 
 package example


### PR DESCRIPTION
#### What type of PR is this?
docs
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: add file type tags for better display of documents
zh: 添加文件类型标签使文档得到更好的显示效果

Before: 
![before](https://user-images.githubusercontent.com/70408571/217147296-9f5112ed-933a-4daa-bb4d-90903b821062.png)
Now:
![atnow](https://user-images.githubusercontent.com/70408571/217147342-140acee8-ca7e-40ea-a956-08ab91d48394.png)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
