### PR TITLE
docs: add Etag middleware

### DIFF
--- a/content/en/docs/hertz/tutorials/basic-feature/middleware/etag.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/middleware/etag.md
@@ -171,6 +171,6 @@ func main() {
     h.Spin()
 }
 ```
-## Full Exapmle
+## Full Example
 
 Refer to the [etag/example](https://github.com/hertz-contrib/etag/tree/main/example) for full usage examples.

--- a/content/en/docs/hertz/tutorials/basic-feature/middleware/etag.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/middleware/etag.md
@@ -7,14 +7,17 @@ description: >
 ---
 
 The `ETag` (or entity tag) HTTP response header is an identifier for a specific version of a resource. It lets caches be more efficient and save bandwidth, as a web server does not need to resend a full response if the content was not changed. Additionally, etags help to prevent simultaneous updates of a resource from overwriting each other ("mid-air collisions").
+Hertz also provides [Etag middleware](https://github.com/hertz-contrib/etag) that can operate on `Etag`, inspired by fiber's [implementation](https://github.com/gofiber/fiber/tree/master/middleware/etag).
 
 ## Install
+
+Download and install
 
 ```shell
 go get github.com/hertz-contrib/etag
 ```
 
-## Import
+Import into your code
 
 ```go
 import "github.com/hertz-contrib/etag"
@@ -55,9 +58,11 @@ func main() {
 
 
 ### WithWeak
+
 `WithWeak` will add `weak prefix` to the front of etag.
 
 Function Signature:
+
 ```go
 func WithWeak() Option
 ```
@@ -86,12 +91,15 @@ func main() {
 ```
 
 ### WithNext
+
 `WithNext` will skip etag middleware when return is true
 
 Function Signature:
+
 ```go
 func WithNext(next NextFunc) Option 
 ```
+
 Sample Code:
 
 ```go
@@ -124,16 +132,18 @@ func main() {
 }
 ```
 
-
 ### WithGenerator
+
 `WithGenerator` will replace default etag generation with yours.
 
 **Note:** you should not add a weak prefix to your custom etag when used with WithWeak
 
 Function Signature:
+
 ```go
 func WithGenerator(gen Generator) Option
 ```
+
 Sample Code:
 
 ```go
@@ -161,4 +171,6 @@ func main() {
     h.Spin()
 }
 ```
+## Full Exapmle
+
 Refer to the [etag/example](https://github.com/hertz-contrib/etag/tree/main/example) for full usage examples.

--- a/content/en/docs/hertz/tutorials/basic-feature/middleware/etag.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/middleware/etag.md
@@ -1,0 +1,164 @@
+---
+title: "Etag"
+date: 2023-02-11
+weight: 14
+description: >
+
+---
+
+The `ETag` (or entity tag) HTTP response header is an identifier for a specific version of a resource. It lets caches be more efficient and save bandwidth, as a web server does not need to resend a full response if the content was not changed. Additionally, etags help to prevent simultaneous updates of a resource from overwriting each other ("mid-air collisions").
+
+## Install
+
+```shell
+go get github.com/hertz-contrib/etag
+```
+
+## Import
+
+```go
+import "github.com/hertz-contrib/etag"
+```
+
+## Example
+
+```go
+package main
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/cloudwego/hertz/pkg/app"
+    "github.com/cloudwego/hertz/pkg/app/server"
+    "github.com/hertz-contrib/etag"
+)
+
+func main() {
+    h := server.Default()
+    h.Use(etag.New())
+    h.GET("/ping", func(ctx context.Context, c *app.RequestContext) {
+        c.String(http.StatusOK, "pong")
+    })
+    h.Spin()
+}
+```
+
+## Configuration
+
+| Configuration           | Default  | Description                                   |
+|------------|---|------------------------------------|
+| WithWeak   | false | Enable weak validator |
+| WithNext | nil | Defines a function to skip etag middleware when return is true |
+|WithGenerator | nil | Custom etag generation logic |
+
+
+
+### WithWeak
+`WithWeak` will add `weak prefix` to the front of etag.
+
+Function Signature:
+```go
+func WithWeak() Option
+```
+Sample Code:
+
+```go
+package main
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/cloudwego/hertz/pkg/app"
+    "github.com/cloudwego/hertz/pkg/app/server"
+    "github.com/hertz-contrib/etag"
+)
+
+func main() {
+    h := server.Default()
+    h.Use(etag.New(etag.WithWeak()))
+    h.GET("/ping", func(ctx context.Context, c *app.RequestContext) {
+        c.String(http.StatusOK, "pong")
+    })
+    h.Spin()
+}
+```
+
+### WithNext
+`WithNext` will skip etag middleware when return is true
+
+Function Signature:
+```go
+func WithNext(next NextFunc) Option 
+```
+Sample Code:
+
+```go
+package main
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/cloudwego/hertz/pkg/app"
+    "github.com/cloudwego/hertz/pkg/app/server"
+    "github.com/hertz-contrib/etag"
+)
+
+func main() {
+    h := server.Default()
+    h.Use(etag.New(etag.WithNext(
+        func(ctx context.Context, c *app.RequestContext) bool {
+            if string(c.Method()) == http.MethodPost {
+                return true
+            } else {
+                return false
+            }
+        },
+    )))
+    h.GET("/ping", func(ctx context.Context, c *app.RequestContext) {
+        c.String(http.StatusOK, "pong")
+    })
+    h.Spin()
+}
+```
+
+
+### WithGenerator
+`WithGenerator` will replace default etag generation with yours.
+
+**Note:** you should not add a weak prefix to your custom etag when used with WithWeak
+
+Function Signature:
+```go
+func WithGenerator(gen Generator) Option
+```
+Sample Code:
+
+```go
+package main
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/cloudwego/hertz/pkg/app"
+    "github.com/cloudwego/hertz/pkg/app/server"
+    "github.com/hertz-contrib/etag"
+)
+
+func main() {
+    h := server.Default()
+    h.Use(etag.New(etag.WithGenerator(
+        func(ctx context.Context, c *app.RequestContext) []byte {
+            return []byte("my-custom-etag")
+        },
+    )))
+    h.GET("/ping", func(ctx context.Context, c *app.RequestContext) {
+        c.String(http.StatusOK, "pong")
+    })
+    h.Spin()
+}
+```
+Refer to the [etag/example](https://github.com/hertz-contrib/etag/tree/main/example) for full usage examples.

--- a/content/zh/docs/hertz/tutorials/basic-feature/middleware/etag.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/middleware/etag.md
@@ -1,0 +1,170 @@
+---
+title: "Etag"
+date: 2023-02-11
+weight: 14
+description: >
+---
+
+`etag`（实体标签）HTTP响应头是一个资源的特定版本的标识符。它让缓存更有效，节省带宽，因为如果内容没有改变，网络服务器不需要重新发送完整的响应。此外，`etag` 有助于防止资源的同时更新互相覆盖（"半空碰撞"）。
+## 安装
+
+```shell
+go get github.com/hertz-contrib/etag
+```
+
+## 导入
+
+```go
+import "github.com/hertz-contrib/etag"
+```
+
+## 示例代码
+
+```go
+package main
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/cloudwego/hertz/pkg/app"
+    "github.com/cloudwego/hertz/pkg/app/server"
+    "github.com/hertz-contrib/etag"
+)
+
+func main() {
+    h := server.Default()
+    h.Use(etag.New())
+    h.GET("/ping", func(ctx context.Context, c *app.RequestContext) {
+        c.String(http.StatusOK, "pong")
+    })
+    h.Spin()
+}
+```
+
+## 配置
+
+| 配置           | 默认值   | 介绍                                   |
+|-------------|-------|--------------------------------------|
+| WithWeak    | false | Enable weak validator |
+| WithNext | nil   | Defines a function to skip etag middleware when return is true |
+|WithGenerator   | nil   | Custom etag generation logic |
+
+
+
+### WithWeak
+`etag` 中间件提供`WithWeak`,调用后将在`etag`的前面加上`weak`的前缀.
+
+函数签名：
+
+```go
+func WithWeak() Option
+```
+
+示例代码：
+
+```go
+package main
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/cloudwego/hertz/pkg/app"
+    "github.com/cloudwego/hertz/pkg/app/server"
+    "github.com/hertz-contrib/etag"
+)
+
+func main() {
+    h := server.Default()
+    h.Use(etag.New(etag.WithWeak()))
+    h.GET("/ping", func(ctx context.Context, c *app.RequestContext) {
+        c.String(http.StatusOK, "pong")
+    })
+    h.Spin()
+}
+```
+
+### WithNext
+`etag` 中间件提供`WithNext`,当调用 `next` 函数返回值为 `true` 时，跳过 `etag` 中间件。
+
+函数签名：
+
+```go
+func WithNext(next NextFunc) Option 
+```
+
+示例代码：
+
+```go
+package main
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/cloudwego/hertz/pkg/app"
+    "github.com/cloudwego/hertz/pkg/app/server"
+    "github.com/hertz-contrib/etag"
+)
+
+func main() {
+    h := server.Default()
+    h.Use(etag.New(etag.WithNext(
+        func(ctx context.Context, c *app.RequestContext) bool {
+            if string(c.Method()) == http.MethodPost {
+                return true
+            } else {
+                return false
+            }
+        },
+    )))
+    h.GET("/ping", func(ctx context.Context, c *app.RequestContext) {
+        c.String(http.StatusOK, "pong")
+    })
+    h.Spin()
+}
+```
+
+
+### WithGenerator
+
+`etag` 中间件提供`WithGenerator`供用户自定义 `etag` 生成器。
+
+**注意**：当与 `WithWeak` 一起使用时，不应该在你的自定义 `etag` 上添加一个弱的前缀。
+
+函数签名：
+
+```go
+func WithGenerator(gen Generator) Option
+```
+
+示例代码：
+
+```go
+package main
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/cloudwego/hertz/pkg/app"
+    "github.com/cloudwego/hertz/pkg/app/server"
+    "github.com/hertz-contrib/etag"
+)
+
+func main() {
+    h := server.Default()
+    h.Use(etag.New(etag.WithGenerator(
+        func(ctx context.Context, c *app.RequestContext) []byte {
+            return []byte("my-custom-etag")
+        },
+    )))
+    h.GET("/ping", func(ctx context.Context, c *app.RequestContext) {
+        c.String(http.StatusOK, "pong")
+    })
+    h.Spin()
+}
+```
+
+完整用法示例详见 [etag/example](https://github.com/hertz-contrib/etag/tree/main/example)

--- a/content/zh/docs/hertz/tutorials/basic-feature/middleware/etag.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/middleware/etag.md
@@ -5,14 +5,18 @@ weight: 14
 description: >
 ---
 
-`etag`（实体标签）HTTP响应头是一个资源的特定版本的标识符。它让缓存更有效，节省带宽，因为如果内容没有改变，网络服务器不需要重新发送完整的响应。此外，`etag` 有助于防止资源的同时更新互相覆盖（"半空碰撞"）。
+`ETag` HTTP 响应头是资源的特定版本的标识符。这可以让缓存更高效，并节省带宽，因为如果内容没有改变，Web 服务器不需要发送完整的响应。而如果内容发生了变化，使用 `ETag` 有助于防止资源的同时更新相互覆盖（“空中碰撞”）。
+Hertz 也提供了可以对 `ETag` 进行操作的 [ETag 中间件](https://github.com/hertz-contrib/etag)，参考了 fiber 的[实现](https://github.com/gofiber/fiber/tree/master/middleware/etag)。
+
 ## 安装
+
+下载并安装
 
 ```shell
 go get github.com/hertz-contrib/etag
 ```
 
-## 导入
+导入
 
 ```go
 import "github.com/hertz-contrib/etag"
@@ -53,7 +57,8 @@ func main() {
 
 
 ### WithWeak
-`etag` 中间件提供`WithWeak`,调用后将在`etag`的前面加上`weak`的前缀.
+
+`etag` 中间件提供`WithWeak`,“用于使用弱验证器”。
 
 函数签名：
 
@@ -86,7 +91,8 @@ func main() {
 ```
 
 ### WithNext
-`etag` 中间件提供`WithNext`,当调用 `next` 函数返回值为 `true` 时，跳过 `etag` 中间件。
+
+`etag` 中间件提供`WithNext`,当“定义的” `next` 函数返回值为 `true` 时，跳过 `etag` 中间件。
 
 函数签名：
 
@@ -129,7 +135,7 @@ func main() {
 
 ### WithGenerator
 
-`etag` 中间件提供`WithGenerator`供用户自定义 `etag` 生成器。
+`etag` 中间件提供`WithGenerator`供用户自定义 `etag` “生成逻辑”。
 
 **注意**：当与 `WithWeak` 一起使用时，不应该在你的自定义 `etag` 上添加一个弱的前缀。
 
@@ -166,5 +172,6 @@ func main() {
     h.Spin()
 }
 ```
+## 完整示例
 
 完整用法示例详见 [etag/example](https://github.com/hertz-contrib/etag/tree/main/example)


### PR DESCRIPTION
#### What type of PR is this?
docs
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: Added `etag` middleware documentation
zh: 新增 `etag` 中间件的文档

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://github.com/cloudwego/hertz/issues/592