### PR TITLE
fix: settings.py is not generated automatically

### DIFF
--- a/content/zh/docs/kitex/Getting started/_index.md
+++ b/content/zh/docs/kitex/Getting started/_index.md
@@ -330,8 +330,7 @@ service Echo {
 |       `-- k-echo.go
 |-- main.go
 `-- script
-    |-- bootstrap.sh
-    `-- settings.py
+    `-- bootstrap.sh
 ```
 
 ### 获取最新的 Kitex 框架


### PR DESCRIPTION
settings.py is for ByteDance's internal deployment.

#### What type of PR is this?
fix: A bug fix

#### What this PR does / why we need it (en: English/zh: Chinese):
en: settings.py is not generated by the open source version of kitex tool.
zh:

#### Which issue(s) this PR fixes:
