### PR TITLE
optimize: details on compatibility with thrift

### DIFF
--- a/content/zh/docs/kitex/Getting started/_index.md
+++ b/content/zh/docs/kitex/Getting started/_index.md
@@ -346,11 +346,17 @@ $ go mod tidy
 
 `github.com/apache/thrift/lib/go/thrift: ambiguous import: found package github.com/apache/thrift/lib/go/thrift in multiple modules`
 
+或
+
+`github.com/cloudwego/kitex@v0.X.X/pkg/utils/thrift.go: not enough arguments in call to t.tProt.WriteMessageBegin`
+
 先执行一遍下述命令，再继续操作：
 ```
 go mod edit -droprequire=github.com/apache/thrift/lib/go/thrift
 go mod edit -replace=github.com/apache/thrift=github.com/apache/thrift@v0.13.0
 ```
+
+这是因为 thrift 官方在 0.14 版本对 thrift 接口做了 breaking change，导致生成代码不兼容。
 
 ### 编写 echo 服务逻辑
 


### PR DESCRIPTION
Add more details on the compatibility issue regarding thrift version 0.13

#### What type of PR is this?
optimize

#### What this PR does / why we need it (en: English/zh: Chinese):
en: add common error message when thrift >=0.14 is used and why we need to use 0.13
zh:

#### Which issue(s) this PR fixes:
