### PR TITLE
doc: add documentation for required parameter

### DIFF
--- a/content/en/docs/hertz/tutorials/basic-feature/binding-and-validate.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/binding-and-validate.md
@@ -57,13 +57,24 @@ func main() {
 
 
 
-### Parameter binding priority
+### Parameter binding precedence
 
 ```text
 path > form > query > cookie > header > json > raw_body
 ```
 > Note: If the request content-type is `application/json`, json unmarshal processing will be done by default before parameter binding
 
+### Required parameter
+
+You can specify a parameter as required with keyword `required` in tag. Both `Bind` and `BindAndValidate` returns error when a required parameter is missing. 
+When multiple tags contain the`required` keyword, parameter with be bound in order of precedence defined above. If none of the tags bind, an error will be returned.
+``` go  
+type TagRequiredReq struct {
+	// when field hertz is missing in json, default error message is binding: expr_path=hertz, cause=missing required parameter
+	Hertz string `json:"hertz,required"`
+	Kitex string `query:"kitex,required" json:"kitex,required" `
+}
+```
 
 ## Common uses
 

--- a/content/en/docs/hertz/tutorials/basic-feature/binding-and-validate.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/binding-and-validate.md
@@ -70,8 +70,9 @@ You can specify a parameter as required with keyword `required` in tag. Both `Bi
 When multiple tags contain the`required` keyword, parameter with be bound in order of precedence defined above. If none of the tags bind, an error will be returned.
 ``` go  
 type TagRequiredReq struct {
-	// when field hertz is missing in json, default error message is binding: expr_path=hertz, cause=missing required parameter
+	// when field hertz is missing in JSON, a required error will be return: binding: expr_path=hertz, cause=missing required parameter
 	Hertz string `json:"hertz,required"`
+	// when field hertz is missing in both query and JSON, a required error will be return: binding: expr_path=hertz, cause=missing required parameter
 	Kitex string `query:"kitex,required" json:"kitex,required" `
 }
 ```

--- a/content/zh/docs/hertz/tutorials/basic-feature/binding-and-validate.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/binding-and-validate.md
@@ -62,6 +62,17 @@ path > form > query > cookie > header > json > raw_body
 ```
 > 注：如果请求的 content-type 为 `application/json`，那么会在参数绑定前做一次 json unmarshal 处理作为兜底。
 
+### 必传参数
+
+通过在 tag 中添加 `required`，可以将参数标记为必传。当绑定失败时`Bind`和`BindAndValidate`将会返回错误。当多个Tag包含`required`时，将会按照优先级绑定。如果所有tag都没有绑定上，则会返回错误。
+``` go  
+type TagRequiredReq struct {
+	// 当JSON中没有hertz字段时，默认错误为binding: expr_path=hertz, cause=missing required parameter
+	Hertz string `json:"hertz,required"`
+	Kitex string `query:"kitex,required" json:"kitex,required" `
+}
+```
+
 ## 常见用法
 
 ### 自定义 bind 和 validate 的 Error

--- a/content/zh/docs/hertz/tutorials/basic-feature/binding-and-validate.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/binding-and-validate.md
@@ -64,7 +64,7 @@ path > form > query > cookie > header > json > raw_body
 
 ### 必传参数
 
-通过在 tag 中添加 `required`，可以将参数标记为必传。当绑定失败时`Bind`和`BindAndValidate`将会返回错误。当多个Tag包含`required`时，将会按照优先级绑定。如果所有tag都没有绑定上，则会返回错误。
+通过在 tag 中添加 `required`，可以将参数标记为必传。当绑定失败时 `Bind` 和 `BindAndValidate` 将会返回错误。当多个 tag 包含 `required` 时，将会按照优先级绑定。如果所有 tag 都没有绑定上，则会返回错误。
 ``` go  
 type TagRequiredReq struct {
 	// 当JSON中没有hertz字段时，默认错误为binding: expr_path=hertz, cause=missing required parameter

--- a/content/zh/docs/hertz/tutorials/basic-feature/binding-and-validate.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/binding-and-validate.md
@@ -67,7 +67,7 @@ path > form > query > cookie > header > json > raw_body
 通过在 tag 中添加 `required`，可以将参数标记为必传。当绑定失败时 `Bind` 和 `BindAndValidate` 将会返回错误。当多个 tag 包含 `required` 时，将会按照优先级绑定。如果所有 tag 都没有绑定上，则会返回错误。
 ``` go  
 type TagRequiredReq struct {
-	// 当JSON中没有hertz字段时，默认错误为binding: expr_path=hertz, cause=missing required parameter
+	// 当 JSON 中没有 hertz 字段时，默认错误为 binding: expr_path=hertz, cause=missing required parameter
 	Hertz string `json:"hertz,required"`
 	Kitex string `query:"kitex,required" json:"kitex,required" `
 }

--- a/content/zh/docs/hertz/tutorials/basic-feature/binding-and-validate.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/binding-and-validate.md
@@ -67,8 +67,9 @@ path > form > query > cookie > header > json > raw_body
 通过在 tag 中添加 `required`，可以将参数标记为必传。当绑定失败时 `Bind` 和 `BindAndValidate` 将会返回错误。当多个 tag 包含 `required` 时，将会按照优先级绑定。如果所有 tag 都没有绑定上，则会返回错误。
 ``` go  
 type TagRequiredReq struct {
-	// 当 JSON 中没有 hertz 字段时，默认错误为 binding: expr_path=hertz, cause=missing required parameter
+	// 当 JSON 中没有 hertz 字段时，会返回 required 错误：binding: expr_path=hertz, cause=missing required parameter
 	Hertz string `json:"hertz,required"`
+	// 当 query 和 JSON 中同时没有 kitex 字段时，会返回 required 错误：binding: expr_path=hertz, cause=missing required parameter"
 	Kitex string `query:"kitex,required" json:"kitex,required" `
 }
 ```


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:
build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
This commit adds documentation for required parameter in [Binding and validate](https://www.cloudwego.io/docs/hertz/tutorials/basic-feature/binding-and-validate).
Required paramter is a important binding feature but it's missing in documentation.

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: add documentation for required parameter
zh: 补充必填参数文档

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
