### PR TITLE
Update tutorial.md ,fixed an inconsistency

### DIFF
--- a/content/zh/docs/kitex/Getting started/tutorial.md
+++ b/content/zh/docs/kitex/Getting started/tutorial.md
@@ -94,7 +94,7 @@ struct GetItemStockResp {
     255: base.BaseResp BaseResp
 }
 
-service GetItemStock {
+service StockService {
     GetItemStockResp GetItemStock(1:GetItemStockReq req)
 }
 ```


### PR DESCRIPTION
Fixed an inconsistency between service name in stock idl and service name in later documentation

#### What type of PR is this?
docs: Documentation only changes

#### Check the PR title.
There is an inconsistency between service name in stock idl, which is 'GetItemStock' and service name in later documentation, which is stockservice

#### (Optional) Translate the PR title into Chinese.
在前面的stock的idl定义中，service name被定义成了GetItemStock，而在后面的文档中一直使用的是stockservice，前后不一致导致按照文档运行库存服务的时候会出现 找不到stockservice 的import错误

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
在前面的stock的idl定义中，service name被定义成了GetItemStock，而在后面的文档中一直使用的是stockservice，前后不一致导致按照文档运行库存服务的时候会出现 找不到stockservice 的import错误，经过我的测试，把最开始的stock idl定义中的service name 改成stockservice与后面保持一致就可以运行成功。请您详细看一下我提的问题，更改之前也请您自己检查一下，我还是小白，不能保证我的理解就是对的。不过我觉得这个问题还是挺严重的。如果不更改的话，一路照着文档做都会报错，让人很摸不着头脑。

