### PR TITLE
fix:change the parameter service to server_name

### DIFF
--- a/content/en/docs/cwgo/getting-started/_index.md
+++ b/content/en/docs/cwgo/getting-started/_index.md
@@ -109,7 +109,7 @@ Let's take thrift as an example:
 4. Generate project layout
 
    ```shell
-   cwgo server -service=a.b.c -type HTTP -idl=idl/hello.thrift
+   cwgo server --server_name a.b.c --type HTTP  --idl idl/hello.thrift -module {{your_module_name}}
    ```
 
 5. Compile and run

--- a/content/en/docs/cwgo/tutorials/client/command.md
+++ b/content/en/docs/cwgo/tutorials/client/command.md
@@ -25,7 +25,8 @@ USAGE:
    cwgo client [command options] [arguments...]
 
 OPTIONS:
-   --service value                                                              Specify the service name.
+   --service value                                                              Specify the server name.(Not recommended)
+   --server_name value                                                          Specify the server name.
    --type value                                                                 Specify the generate type. (RPC or HTTP) (default: "RPC")
    --module value, --mod value                                                  Specify the Go module name to generate go.mod.
    --idl value                                                                  Specify the IDL file path. (.thrift or .proto)
@@ -38,9 +39,13 @@ OPTIONS:
    --help, -h                                                                   show help (default: false)
 ```
 
+## Attention
+- service is not recommended and will be removed from v0.2.0
+
 ## Specification
 
-- service: Specify the service name for functions such as service registration and discovery
+- service: Specify the service name for functions such as service registration and discovery(Not recommended)
+- server_name: Specify the service name for functions such as service registration and discovery
 - type: Specify the generation type, support parameters RPC and HTTP, default to RPC
 - module/mod: Specify the go mod name, which must be specified outside of GOPATH. In GOPATH, the default name is the path relative to GOPATH
 - idl: Specify the main IDL file path

--- a/content/en/docs/cwgo/tutorials/client/example_pb.md
+++ b/content/en/docs/cwgo/tutorials/client/example_pb.md
@@ -35,7 +35,7 @@ service HelloService {
 > Note: 项目位于非 GOPATH 下必须指定 gomod，GOPATH 下默认以相对于 GOPATH 的路径作为名字，可不指定 gomod。
 
 ```sh
-cwgo client  --type RPC  --idl hello.proto  --service hellotest --module {{your_module_name}} -I .
+cwgo client  --type RPC  --idl hello.proto  --server_name hellotest --module {{your_module_name}} -I .
 ```
 
 ### Generate Code
@@ -161,7 +161,7 @@ service HelloService {
 > Note: If the project is located outside of GOPATH, gomod must be specified. GOPATH defaults to a path relative to GOPATH as the name, and gomod may not be specified.
 
 ```sh
-cwgo client  --type HTTP  --idl hello.proto  --service hellotest --module {{your_module_name}}
+cwgo client  --type HTTP  --idl hello.proto  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### Generate Code

--- a/content/en/docs/cwgo/tutorials/client/example_thrift.md
+++ b/content/en/docs/cwgo/tutorials/client/example_thrift.md
@@ -33,7 +33,7 @@ service HelloService {
 > Note: If the project is located outside of GOPATH, gomod must be specified. GOPATH defaults to a path relative to GOPATH as the name, and gomod may not be specified.
 
 ```sh
-cwgo client  --type RPC  --idl hello.thrift  --service hellotest --module {{your_module_name}}
+cwgo client  --type RPC  --idl hello.thrift  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### Generate Code
@@ -91,7 +91,7 @@ service HelloService {
 > Note: If the project is located outside of GOPATH, gomod must be specified. GOPATH defaults to a path relative to GOPATH as the name, and gomod may not be specified.
 
 ```sh
-cwgo client  --type HTTP  --idl hello.thrift  --service hellotest --module {{your_module_name}}
+cwgo client  --type HTTP  --idl hello.thrift  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### Generate Code

--- a/content/en/docs/cwgo/tutorials/server/command.md
+++ b/content/en/docs/cwgo/tutorials/server/command.md
@@ -25,7 +25,8 @@ USAGE:
    cwgo server [command options] [arguments...]
 
 OPTIONS:
-   --service value                                                              Specify the service name.
+   --service value                                                              Specify the server name.(Not recommended)
+   --server_name value                                                          Specify the server name.
    --type value                                                                 Specify the generate type. (RPC or HTTP) (default: "RPC")
    --module value, --mod value                                                  Specify the Go module name to generate go.mod.
    --idl value                                                                  Specify the IDL file path. (.thrift or .proto)
@@ -38,10 +39,13 @@ OPTIONS:
    --hex                                                                        Add HTTP listen for Kitex. (default: false)
    --help, -h                                                                   show help (default: false)
 ```
+## Attention
+- service is not recommended and will be removed from v0.2.0
+
 
 ## Specification
-
-- service: Specify the service name for functions such as service registration and discovery
+- service: Specify the service name for functions such as service registration and discovery(Not recommended)
+- server_name: Specify the service name for functions such as service registration and discovery
 - type: Specify the generation type, support parameters RPC and HTTP, default to RPC
 - module/mod: Specify the go mod name, which must be specified outside of GOPATH. In GOPATH, the default name is the path relative to GOPATH
 - idl: Specify the main IDL file path

--- a/content/en/docs/cwgo/tutorials/server/example_pb.md
+++ b/content/en/docs/cwgo/tutorials/server/example_pb.md
@@ -35,7 +35,7 @@ service HelloService {
 > Note: If the project is located outside of GOPATH, gomod must be specified. GOPATH defaults to a path relative to GOPATH as the name, and gomod may not be specified.
 
 ```sh
-cwgo server  --type RPC  --idl hello.proto  --service hellotest --module {{your_module_name}} -I .
+cwgo server  --type RPC  --idl hello.proto  --server_name hellotest --module {{your_module_name}} -I .
 ```
 
 ### Generate Code
@@ -161,7 +161,7 @@ service HelloService {
 > Note: If the project is located outside of GOPATH, gomod must be specified. GOPATH defaults to a path relative to GOPATH as the name, and gomod may not be specified.
 
 ```sh
-cwgo server  --type HTTP  --idl hello.proto  --service hellotest --module {{your_module_name}}
+cwgo server  --type HTTP  --idl hello.proto  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### Generate Code

--- a/content/en/docs/cwgo/tutorials/server/example_thrift.md
+++ b/content/en/docs/cwgo/tutorials/server/example_thrift.md
@@ -31,7 +31,7 @@ service HelloService {
 > Note: If the project is located outside of GOPATH, gomod must be specified. GOPATH defaults to a path relative to GOPATH as the name, and gomod may not be specified.
 
 ```sh
-cwgo server  --type RPC  --idl hello.thrift  --service hellotest --module {{your_module_name}}
+cwgo server  --type RPC  --idl hello.thrift  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### Generate Code
@@ -69,7 +69,7 @@ service HelloService {
 > Note: If the project is located outside of GOPATH, gomod must be specified. GOPATH defaults to a path relative to GOPATH as the name, and gomod may not be specified.
 
 ```sh
-cwgo server  --type HTTP  --idl hello.thrift  --service hellotest --module {{your_module_name}}
+cwgo server  --type HTTP  --idl hello.thrift  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### Generate Code

--- a/content/zh/docs/cwgo/getting-started/_index.md
+++ b/content/zh/docs/cwgo/getting-started/_index.md
@@ -109,7 +109,7 @@ cwgo 的具体使用请参考[命令行工具](/zh/docs/cwgo/tutorials/cli)。
 4. 生成项目 layout
 
    ```shell
-   cwgo server -service=a.b.c -type HTTP  -idl=idl/hello.thrift
+   cwgo server --server_name a.b.c --type HTTP  --idl idl/hello.thrift -module {{your_module_name}}
    ```
 
 5. 编译运行

--- a/content/zh/docs/cwgo/tutorials/client/command.md
+++ b/content/zh/docs/cwgo/tutorials/client/command.md
@@ -25,7 +25,8 @@ USAGE:
    cwgo client [command options] [arguments...]
 
 OPTIONS:
-   --service value                                                              Specify the service name.
+   --service value                                                              Specify the server name.(Not recommended)
+   --server_name value                                                          Specify the server name.
    --type value                                                                 Specify the generate type. (RPC or HTTP) (default: "RPC")
    --module value, --mod value                                                  Specify the Go module name to generate go.mod.
    --idl value                                                                  Specify the IDL file path. (.thrift or .proto)
@@ -38,9 +39,12 @@ OPTIONS:
    --help, -h                                                                   show help (default: false)
 ```
 
-## 详细参数
+## 注意
+- service 不建议使用，将在v0.2.0下架
 
-- service：指定服务名称，用于服务注册与发现等功能
+## 详细参数
+- service:指定服务名称，用于服务注册、服务发现等功能(不建议使用)
+- server_name:服务名称，用于服务注册、服务发现等功能
 - type：指定生成类型，支持参数 RPC、HTTP，默认为 RPC
 - module/mod：指定 go mod 名称，非 GOPATH 下必须指定，GOPATH 下默认以相对于 GOPATH 的路径作为名字
 - idl：指定主 IDL 文件路径

--- a/content/zh/docs/cwgo/tutorials/client/example_pb.md
+++ b/content/zh/docs/cwgo/tutorials/client/example_pb.md
@@ -35,7 +35,7 @@ service HelloService {
 > Note: 项目位于非 GOPATH 下必须指定 gomod，GOPATH 下默认以相对于 GOPATH 的路径作为名字，可不指定 gomod。
 
 ```sh
-cwgo client  --type RPC  --idl hello.proto  --service hellotest --module {{your_module_name}} -I .
+cwgo client  --type RPC  --idl hello.proto  --server_name hellotest --module {{your_module_name}} -I .
 ```
 
 ### 生成代码
@@ -161,7 +161,7 @@ service HelloService {
 > Note: 项目位于非 GOPATH 下必须指定 gomod，GOPATH 下默认以相对于 GOPATH 的路径作为名字，可不指定 gomod。
 
 ```sh
-cwgo client  --type HTTP  --idl hello.proto  --service hellotest --module {{your_module_name}}
+cwgo client  --type HTTP  --idl hello.proto  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### 生成代码

--- a/content/zh/docs/cwgo/tutorials/client/example_thrift.md
+++ b/content/zh/docs/cwgo/tutorials/client/example_thrift.md
@@ -33,7 +33,7 @@ service HelloService {
 > Note: 项目位于非 GOPATH 下必须指定 gomod，GOPATH 下默认以相对于 GOPATH 的路径作为名字，可不指定 gomod。
 
 ```sh
-cwgo client  --type RPC  --idl hello.thrift  --service hellotest --module {{your_module_name}}
+cwgo client  --type RPC  --idl hello.thrift  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### 生成代码
@@ -91,7 +91,7 @@ service HelloService {
 > Note: 项目位于非 GOPATH 下必须指定 gomod，GOPATH 下默认以相对于 GOPATH 的路径作为名字，可不指定 gomod。
 
 ```sh
-cwgo client  --type HTTP  --idl hello.thrift  --service hellotest --module {{your_module_name}}
+cwgo client  --type HTTP  --idl hello.thrift  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### 生成代码

--- a/content/zh/docs/cwgo/tutorials/server/command.md
+++ b/content/zh/docs/cwgo/tutorials/server/command.md
@@ -25,7 +25,8 @@ USAGE:
    cwgo server [command options] [arguments...]
 
 OPTIONS:
-   --service value                                                              Specify the service name.
+   --service value                                                              Specify the server name.(Not recommended)
+   --server_name value                                                          Specify the server name.
    --type value                                                                 Specify the generate type. (RPC or HTTP) (default: "RPC")
    --module value, --mod value                                                  Specify the Go module name to generate go.mod.
    --idl value                                                                  Specify the IDL file path. (.thrift or .proto)
@@ -38,10 +39,12 @@ OPTIONS:
    --hex                                                                        Add HTTP listen for Kitex. (default: false)
    --help, -h                                                                   show help (default: false)
 ```
+## 注意
+- service 不建议使用，将在v0.2.0下架
 
 ## 详细参数
-
-- service：指定服务名称，用于服务注册与发现等功能
+- service:指定服务名称，用于服务注册、服务发现等功能(不建议使用)
+- server_name:服务名称，用于服务注册、服务发现等功能
 - type：指定生成类型，支持参数 RPC、HTTP，默认为 RPC
 - module/mod：指定 go mod 名称，非 GOPATH 下必须指定，GOPATH 下默认以相对于 GOPATH 的路径作为名字
 - idl：指定主 IDL 文件路径

--- a/content/zh/docs/cwgo/tutorials/server/example_pb.md
+++ b/content/zh/docs/cwgo/tutorials/server/example_pb.md
@@ -35,7 +35,7 @@ service HelloService {
 > Note: 项目位于非 GOPATH 下必须指定 gomod，GOPATH 下默认以相对于 GOPATH 的路径作为名字，可不指定 gomod。
 
 ```sh
-cwgo server  --type RPC  --idl hello.proto  --service hellotest --module {{your_module_name}} -I .
+cwgo server  --type RPC  --idl hello.proto  --server_name hellotest --module {{your_module_name}} -I .
 ```
 
 ### 生成代码
@@ -161,7 +161,7 @@ service HelloService {
 > Note: 项目位于非 GOPATH 下必须指定 gomod，GOPATH 下默认以相对于 GOPATH 的路径作为名字，可不指定 gomod。
 
 ```sh
-cwgo server  --type HTTP  --idl hello.proto  --service hellotest --module {{your_module_name}}
+cwgo server  --type HTTP  --idl hello.proto  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### 生成代码

--- a/content/zh/docs/cwgo/tutorials/server/example_thrift.md
+++ b/content/zh/docs/cwgo/tutorials/server/example_thrift.md
@@ -31,7 +31,7 @@ service HelloService {
 > Note: 项目位于非 GOPATH 下必须指定 gomod，GOPATH 下默认以相对于 GOPATH 的路径作为名字，可不指定 gomod。
 
 ```sh
-cwgo server  --type RPC  --idl hello.thrift  --service hellotest --module {{your_module_name}}
+cwgo server  --type RPC  --idl hello.thrift  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### 生成代码
@@ -69,7 +69,7 @@ service HelloService {
 > Note: 项目位于非 GOPATH 下必须指定 gomod，GOPATH 下默认以相对于 GOPATH 的路径作为名字，可不指定 gomod。
 
 ```sh
-cwgo server  --type HTTP  --idl hello.thrift  --service hellotest --module {{your_module_name}}
+cwgo server  --type HTTP  --idl hello.thrift  --server_name hellotest --module {{your_module_name}}
 ```
 
 ### 生成代码


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
en: Change the parameter service to server_name.The service parameter name is not easily understood by the user.
zh: 修复service参数名称为server_name,service参数名称不容易被用户理解。

#### Which issue(s) this PR fixes:

