### PR TITLE
refine document for opentelemetry-compile-time-instrumentation

### DIFF
--- a/content/en/docs/hertz/tutorials/third-party/open-telemetry.md
+++ b/content/en/docs/hertz/tutorials/third-party/open-telemetry.md
@@ -182,5 +182,3 @@ For a full usage: [example](https://github.com/cloudwego/hertz-examples/tree/mai
 If you don't want to use open-telemetry through sdk, you can also use open-telemetry's official recommended compile-time instrumentation, which allows users to automatically use open-telemetry without modifying the source code, related links:
 1. [open-telemetry official project link](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
 2. [open-telemetry official technical blog](https://opentelemetry.io/blog/2025/go-compile-time-instrumentation)
-3. [alibaba compile-time instrumentation](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
-4. [datadog compile-time instrumentation implementation](https://github.com/datadog/orchestrion)

--- a/content/en/docs/hertz/tutorials/third-party/open-telemetry.md
+++ b/content/en/docs/hertz/tutorials/third-party/open-telemetry.md
@@ -176,3 +176,11 @@ func main() {
 ## Full Examples
 
 For a full usage: [example](https://github.com/cloudwego/hertz-examples/tree/main/opentelemetry)
+
+## More
+### Compile-time instrumentation
+If you don't want to use open-telemetry through sdk, you can also use open-telemetry's official recommended compile-time instrumentation, which allows users to automatically use open-telemetry without modifying the source code, related links:
+1. [open-telemetry official project link](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
+2. [open-telemetry official technical blog](https://opentelemetry.io/blog/2025/go-compile-time-instrumentation)
+3. [alibaba compile-time instrumentation](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
+4. [datadog compile-time instrumentation implementation](https://github.com/datadog/orchestrion)

--- a/content/en/docs/kitex/Tutorials/third-party/observability.md
+++ b/content/en/docs/kitex/Tutorials/third-party/observability.md
@@ -204,3 +204,11 @@ func main()  {
     }
 }
 ```
+
+## More
+### Compile-time instrumentation
+If you don't want to use open-telemetry through sdk, you can also use open-telemetry's official recommended compile-time instrumentation, which allows users to automatically use open-telemetry without modifying the source code, related links:
+1. [open-telemetry official project link](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
+2. [open-telemetry official technical blog](https://opentelemetry.io/blog/2025/go-compile-time-instrumentation)
+3. [alibaba compile-time instrumentation](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
+4. [datadog compile-time instrumentation implementation](https://github.com/datadog/orchestrion)

--- a/content/en/docs/kitex/Tutorials/third-party/observability.md
+++ b/content/en/docs/kitex/Tutorials/third-party/observability.md
@@ -210,5 +210,3 @@ func main()  {
 If you don't want to use open-telemetry through sdk, you can also use open-telemetry's official recommended compile-time instrumentation, which allows users to automatically use open-telemetry without modifying the source code, related links:
 1. [open-telemetry official project link](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
 2. [open-telemetry official technical blog](https://opentelemetry.io/blog/2025/go-compile-time-instrumentation)
-3. [alibaba compile-time instrumentation](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
-4. [datadog compile-time instrumentation implementation](https://github.com/datadog/orchestrion)

--- a/content/zh/docs/hertz/tutorials/third-party/open-telemetry.md
+++ b/content/zh/docs/hertz/tutorials/third-party/open-telemetry.md
@@ -172,3 +172,10 @@ func main() {
 ## 完整使用示例
 
 完整的使用示例详见 [example](https://github.com/cloudwego/hertz-examples/tree/main/opentelemetry)
+
+## 更多
+如果您不想通过sdk的方式接入open-telemetry，您还可以使用open-telemetry官方推荐的编译时注入方案，该方案可以使得用户在不修改源代码的前提下自动接入open-telemetry，相关链接：
+1. [open-telemetry官方项目链接](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
+2. [open-telemetry官方技术博客](https://opentelemetry.io/blog/2025/go-compile-time-instrumentation)
+3. [alibaba编译时注入实现](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
+4. [datadog编译时注入实现](https://github.com/datadog/orchestrion)

--- a/content/zh/docs/hertz/tutorials/third-party/open-telemetry.md
+++ b/content/zh/docs/hertz/tutorials/third-party/open-telemetry.md
@@ -174,6 +174,7 @@ func main() {
 完整的使用示例详见 [example](https://github.com/cloudwego/hertz-examples/tree/main/opentelemetry)
 
 ## 更多
+### 编译时注入
 如果您不想通过sdk的方式接入open-telemetry，您还可以使用open-telemetry官方推荐的编译时注入方案，该方案可以使得用户在不修改源代码的前提下自动接入open-telemetry，相关链接：
 1. [open-telemetry官方项目链接](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
 2. [open-telemetry官方技术博客](https://opentelemetry.io/blog/2025/go-compile-time-instrumentation)

--- a/content/zh/docs/hertz/tutorials/third-party/open-telemetry.md
+++ b/content/zh/docs/hertz/tutorials/third-party/open-telemetry.md
@@ -178,5 +178,3 @@ func main() {
 如果您不想通过sdk的方式接入open-telemetry，您还可以使用open-telemetry官方推荐的编译时注入方案，该方案可以使得用户在不修改源代码的前提下自动接入open-telemetry，相关链接：
 1. [open-telemetry官方项目链接](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
 2. [open-telemetry官方技术博客](https://opentelemetry.io/blog/2025/go-compile-time-instrumentation)
-3. [alibaba编译时注入实现](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
-4. [datadog编译时注入实现](https://github.com/datadog/orchestrion)

--- a/content/zh/docs/kitex/Tutorials/third-party/observability.md
+++ b/content/zh/docs/kitex/Tutorials/third-party/observability.md
@@ -208,5 +208,3 @@ func main()  {
 如果您不想通过sdk的方式接入open-telemetry，您还可以使用open-telemetry官方推荐的编译时注入方案，该方案可以使得用户在不修改源代码的前提下自动接入open-telemetry，相关链接：
 1. [open-telemetry官方项目链接](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
 2. [open-telemetry官方技术博客](https://opentelemetry.io/blog/2025/go-compile-time-instrumentation)
-3. [alibaba编译时注入实现](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
-4. [datadog编译时注入实现](https://github.com/datadog/orchestrion)

--- a/content/zh/docs/kitex/Tutorials/third-party/observability.md
+++ b/content/zh/docs/kitex/Tutorials/third-party/observability.md
@@ -202,3 +202,11 @@ func main()  {
     }
 }
 ```
+
+## 更多
+### 编译时注入
+如果您不想通过sdk的方式接入open-telemetry，您还可以使用open-telemetry官方推荐的编译时注入方案，该方案可以使得用户在不修改源代码的前提下自动接入open-telemetry，相关链接：
+1. [open-telemetry官方项目链接](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
+2. [open-telemetry官方技术博客](https://opentelemetry.io/blog/2025/go-compile-time-instrumentation)
+3. [alibaba编译时注入实现](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
+4. [datadog编译时注入实现](https://github.com/datadog/orchestrion)


### PR DESCRIPTION
refine document for opentelemetry-compile-time-instrumentation
1. [open-telemetry official project link](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
2. [open-telemetry official technical blog](https://opentelemetry.io/blog/2025/go-compile-time-instrumentation)
3. [alibaba compile-time instrumentation](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
4. [datadog compile-time instrumentation implementation](https://github.com/datadog/orchestrion)