### PR TITLE
docs: update eino doc lambda_guide.md

### DIFF
--- a/content/zh/docs/eino/core_modules/components/lambda_guide.md
+++ b/content/zh/docs/eino/core_modules/components/lambda_guide.md
@@ -54,7 +54,7 @@ type Transform[I, O, TOption any] func(ctx context.Context, input *schema.Stream
 - InvokableLambda
 
 ```go
-// input 和 output 类型为自定义的任何类型
+// input 和 output 为自定义的任意类型
 lambda := compose.InvokableLambda(func(ctx context.Context, input string) (output string, err error) {
     // some logic
 })
@@ -63,7 +63,7 @@ lambda := compose.InvokableLambda(func(ctx context.Context, input string) (outpu
 - StreamableLambda
 
 ```go
-// input 和 output 类型为自定义的任何类型
+// input 可以是任意类型，output 必须是 *schema.StreamReader[O]，其中 O 可以是任意类型
 lambda := compose.StreamableLambda(func(ctx context.Context, input string) (output *schema.StreamReader[string], err error) {
     // some logic
 })
@@ -72,7 +72,7 @@ lambda := compose.StreamableLambda(func(ctx context.Context, input string) (outp
 - CollectableLambda
 
 ```go
-// input 和 output 类型为自定义的任何类型
+// input 必须是 *schema.StreamReader[I]，其中 I 可以是任意类型，output 可以是任意类型
 lambda := compose.CollectableLambda(func(ctx context.Context, input *schema.StreamReader[string]) (output string, err error) {
     // some logic
 })
@@ -81,7 +81,7 @@ lambda := compose.CollectableLambda(func(ctx context.Context, input *schema.Stre
 - TransformableLambda
 
 ```go
-// input 和 output 类型为自定义的任何类型
+// input 和 output 必须是 *schema.StreamReader[I]，其中 I 可以是任意类型
 lambda := compose.TransformableLambda(func(ctx context.Context, input *schema.StreamReader[string]) (output *schema.StreamReader[string], err error) {
     // some logic
 })


### PR DESCRIPTION
#### What type of PR is this?
docs: Documentation only changes


#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
Modify the type definition of the lambda example in lambda_guide.md. 
The original code wrongly declared that both the input and output could be any custom types.
The correct definition is based on the code implementation in eino, specifically in the file [types_lambda.go](https://github.com/cloudwego/eino/blob/main/compose/types_lambda.go) around lines 110 - 140.