### PR TITLE
docs(Eino):Uniform context variable naming

### DIFF
--- a/content/en/docs/eino/ecosystem/tool/tool_mcp.md
+++ b/content/en/docs/eino/ecosystem/tool/tool_mcp.md
@@ -55,7 +55,7 @@ Then use the Client to create the adapter , which implements Eino Tool:
 ```go
 import "github.com/cloudwego/eino-ext/components/tool/mcp"
 
-tools, err := mcp.GetTools(ctx, &mcp.Config{Cli: cli})
+mcpTools, err := mcp.GetTools(ctx, &mcp.Config{Cli: cli})
 ```
 
 You can call this adapter directly:

--- a/content/zh/docs/eino/ecosystem_integration/tool/tool_mcp.md
+++ b/content/zh/docs/eino/ecosystem_integration/tool/tool_mcp.md
@@ -57,7 +57,7 @@ _, err = cli.Initialize(ctx, initRequest)
 ```go
 import "github.com/cloudwego/eino-ext/components/tool/mcp"
 
-tools, err := mcp.GetTools(ctx, &mcp.Config{Cli: cli})
+mcpTools, err := mcp.GetTools(ctx, &mcp.Config{Cli: cli})
 ```
 
 tool 可以直接调用：


### PR DESCRIPTION
Uniform variable names, changing tools to mcpTools to avoid misunderstandings