### PR TITLE
docs: 明确NewOpenTelemetryProvider的重复调用规范（关联Issue #1327）

### DIFF
--- a/content/zh/docs/kitex/Tutorials/third-party/observability.md
+++ b/content/zh/docs/kitex/Tutorials/third-party/observability.md
@@ -172,6 +172,7 @@ func main(){
 ```
 
 Server
+注意事项：重复调用`NewOpenTelemetryProvider`时，必须先`Shutdown`前一个provider，再`NewOpenTelemetryProvider`，否则会导致资源泄漏和网络连接混乱。
 
 ```go
 import (

--- a/content/zh/docs/kitex/Tutorials/third-party/observability.md
+++ b/content/zh/docs/kitex/Tutorials/third-party/observability.md
@@ -172,6 +172,7 @@ func main(){
 ```
 
 Server
+
 注意事项：重复调用`NewOpenTelemetryProvider`时，必须先`Shutdown`前一个provider，再`NewOpenTelemetryProvider`，否则会导致资源泄漏和网络连接混乱。
 
 ```go


### PR DESCRIPTION
## 修改说明  
此PR针对 Issue #1327，完善"[github.com/kitex-contrib/obs-opentelemetry/provider](https://github.com/kitex-contrib/obs-opentelemetry/provider)"中的NewOpenTelemetryProvider的调用规范说明，避免资源泄漏和网络连接混乱问题。  

### 主要变更  
在文档中明确指出重复调用NewOpenTelemetryProvider时的资源泄漏问题，明确要求程序员在多次调用NewOpenTelemetryProvider时每次都要先shutdown原来的。
![image](https://github.com/user-attachments/assets/b028b53e-b146-4e22-93e8-cae21547a342)


