### PR TITLE
修复milvus的indexer文档，缺乏”document配置必须搭配fields配置“这一信息，导致容易误用问题

### DIFF
--- a/content/en/docs/eino/ecosystem_integration/indexer/indexer_milvus.md
+++ b/content/en/docs/eino/ecosystem_integration/indexer/indexer_milvus.md
@@ -116,6 +116,7 @@ type IndexerConfig struct {
     // Default Collection config
     // Collection is the collection name in milvus database
     // Optional, and the default value is "eino_collection"
+    // If you want to use this configuration, you must include the Fields configuration
     Collection string
     // Description is the description for collection
     // Optional, and the default value is "the collection for eino"

--- a/content/zh/docs/eino/ecosystem_integration/indexer/indexer_milvus.md
+++ b/content/zh/docs/eino/ecosystem_integration/indexer/indexer_milvus.md
@@ -115,6 +115,7 @@ type IndexerConfig struct {
 	// 默认集合配置
 	// Collection 是 milvus 数据库中的集合名称
 	// 可选，默认值为 "eino_collection"
+    // 如果你想使用这个配置，必须加上Field配置，否则无法正常运行
 	Collection string
 	// Description 是集合的描述
 	// 可选，默认值为 "the collection for eino"


### PR DESCRIPTION
closed #1330 

如果要使用milvus的indexer，指定collection的时候，如果要使用自己创建的collection，必须指定Fields，否则会报错，无法正常使用，详情见https://github.com/cloudwego/eino-ext/issues/252

原文档缺乏这部分信息补充，导致自己排查了很久才发现相应问题，这个pr补充了相应信息