### PR TITLE
Revert "docs(kitex): fix generic example typo"

### DIFF
--- a/content/en/docs/kitex/Tutorials/advanced-feature/generic-call/basic_usage.md
+++ b/content/en/docs/kitex/Tutorials/advanced-feature/generic-call/basic_usage.md
@@ -150,12 +150,12 @@ includes := map[string]string{
    "a/z.thrift": "namespace go kitex.test.server",
 }
 
-p, err := generic.NewThriftContentWithAbsIncludePathProvider(content, includes)
+p, err := generic.NewThriftContentWithAbsIncludePathProvider(path, includes)
 if err != nil {
     panic(err)
 }
 
-p, err := generic.NewThriftContentWithAbsIncludePathProviderWithDynamicGo(content, includes)
+p, err := generic.NewThriftContentWithAbsIncludePathProviderWithDynamicGo(path, includes)
 if err != nil {
     panic(err)
 }

--- a/content/zh/docs/kitex/Tutorials/advanced-feature/generic-call/basic_usage.md
+++ b/content/zh/docs/kitex/Tutorials/advanced-feature/generic-call/basic_usage.md
@@ -150,12 +150,12 @@ includes := map[string]string{
    "a/z.thrift": "namespace go kitex.test.server",
 }
 
-p, err := generic.NewThriftContentWithAbsIncludePathProvider(content, includes)
+p, err := generic.NewThriftContentWithAbsIncludePathProvider(path, includes)
 if err != nil {
     panic(err)
 }
 
-p, err := generic.NewThriftContentWithAbsIncludePathProviderWithDynamicGo(content, includes)
+p, err := generic.NewThriftContentWithAbsIncludePathProviderWithDynamicGo(path, includes)
 if err != nil {
     panic(err)
 }


### PR DESCRIPTION
Reverts cloudwego/cloudwego.github.io#1349