### PR TITLE
 docs(hertz):解决log示例代码的错误

### DIFF
--- a/content/en/docs/hertz/tutorials/observability/log.md
+++ b/content/en/docs/hertz/tutorials/observability/log.md
@@ -18,7 +18,7 @@ func AccessLog() app.HandlerFunc {
 		start := time.Now()
 		c.Next(ctx)
 		end := time.Now()
-		latency := end.Sub(start).Microseconds
+		latency := end.Sub(start).Microseconds()
 		hlog.CtxTracef(ctx, "status=%d cost=%d method=%s full_path=%s client_ip=%s host=%s",
 			c.Response.StatusCode(), latency,
 			c.Request.Header.Method(), c.Request.URI().PathOriginal(), c.ClientIP(), c.Request.Host())

--- a/content/zh/docs/hertz/tutorials/observability/log.md
+++ b/content/zh/docs/hertz/tutorials/observability/log.md
@@ -18,7 +18,7 @@ func AccessLog() app.HandlerFunc {
 		start := time.Now()
 		c.Next(ctx)
 		end := time.Now()
-		latency := end.Sub(start).Microseconds
+		latency := end.Sub(start).Microseconds()
 		hlog.CtxTracef(ctx, "status=%d cost=%d method=%s full_path=%s client_ip=%s host=%s",
 			c.Response.StatusCode(), latency,
 			c.Request.Header.Method(), c.Request.URI().PathOriginal(), c.ClientIP(), c.Request.Host())


### PR DESCRIPTION
如何打印日志
hertz 中可以直接调用 pkg/common/hlog 包下的方法打日志，该方法会调用 defaultLogger 上对应的方法。如实现一个打印 AccessLog 的中间件。
示例函数中的Microseconds 修正为Microseconds()