### PR TITLE
docs(hertz)：解决日志示例代码的错误

### DIFF
--- a/content/en/docs/hertz/tutorials/observability/log.md
+++ b/content/en/docs/hertz/tutorials/observability/log.md
@@ -18,7 +18,7 @@ func AccessLog() app.HandlerFunc {
 		start := time.Now()
 		c.Next(ctx)
 		end := time.Now()
-		latency := end.Sub(start).Microseconds
+		latency := end.Sub(start).Microseconds()
 		hlog.CtxTracef(ctx, "status=%d cost=%d method=%s full_path=%s client_ip=%s host=%s",
 			c.Response.StatusCode(), latency,
 			c.Request.Header.Method(), c.Request.URI().PathOriginal(), c.ClientIP(), c.Request.Host())

--- a/content/zh/docs/hertz/tutorials/observability/log.md
+++ b/content/zh/docs/hertz/tutorials/observability/log.md
@@ -18,7 +18,7 @@ func AccessLog() app.HandlerFunc {
 		start := time.Now()
 		c.Next(ctx)
 		end := time.Now()
-		latency := end.Sub(start).Microseconds
+		latency := end.Sub(start).Microseconds()
 		hlog.CtxTracef(ctx, "status=%d cost=%d method=%s full_path=%s client_ip=%s host=%s",
 			c.Response.StatusCode(), latency,
 			c.Request.Header.Method(), c.Request.URI().PathOriginal(), c.ClientIP(), c.Request.Host())


### PR DESCRIPTION
解决Herz 中英文文档中可观测性质-日志模块的,示例代码问题

latency := end.Sub(start).Microseconds 修正为
latency := end.Sub(start).Microseconds()