### PR TITLE
docs(hz): Remove SSE from tutorials/third-party/_index.md and Synchronize keywords

### DIFF
--- a/content/en/docs/hertz/tutorials/third-party/protocol/_index.md
+++ b/content/en/docs/hertz/tutorials/third-party/protocol/_index.md
@@ -2,7 +2,7 @@
 title: "Protocol"
 date: 2022-05-23
 weight: 1
-keywords: ["Websocket", "HTTP2", "HTTP3", "SSE"]
+keywords: ["Websocket", "HTTP2", "HTTP3"]
 description: "Protocol extensions supported by Hertz."
 ---
 
@@ -17,7 +17,3 @@ Hertz references [net/http2](https://github.com/golang/net/tree/master/http2) to
 ## HTTP3
 
 Hertz reference [quic-go](https://github.com/quic-go/quic-go) to implement support for HTTP3.
-
-## SSE
-
-Hertz supports SSE, allowing the server to send events to the client through simple HTTP response.

--- a/content/en/docs/hertz/tutorials/third-party/protocol/_index.md
+++ b/content/en/docs/hertz/tutorials/third-party/protocol/_index.md
@@ -2,7 +2,7 @@
 title: "Protocol"
 date: 2022-05-23
 weight: 1
-keywords: ["Websocket", "HTTP2", "HTTP3"]
+keywords: ["TLS", "ALPN", "Websocket", "HTTP2", "HTTP3"]
 description: "Protocol extensions supported by Hertz."
 ---
 

--- a/content/zh/docs/hertz/tutorials/third-party/protocol/_index.md
+++ b/content/zh/docs/hertz/tutorials/third-party/protocol/_index.md
@@ -2,7 +2,7 @@
 title: "协议"
 date: 2022-05-23
 weight: 1
-keywords: ["TLS", "ALPN", "Websocket", "HTTP2", "HTTP3", "SSE"]
+keywords: ["TLS", "ALPN", "Websocket", "HTTP2", "HTTP3"]
 description: "Hertz 支持的协议扩展。"
 ---
 
@@ -17,7 +17,3 @@ Hertz 参考 [net/http2](https://github.com/golang/net/tree/master/http2) 实现
 ## HTTP3
 
 Hertz 参考 [quic-go](https://github.com/quic-go/quic-go) 实现了对 HTTP3 的支持。
-
-## SSE
-
-Hertz 支持 SSE，允许服务器端通过简单的 HTTP 响应向客户端发送事件。


### PR DESCRIPTION
当前对于协议的三方扩展的索引页面不再需要 SSE 的相关内容