### PR TITLE
docs(hertz): fix misleading file path in quick start tutorial

### DIFF
--- a/content/zh/docs/hertz/getting-started/_index.md
+++ b/content/zh/docs/hertz/getting-started/_index.md
@@ -117,7 +117,7 @@ hz 是 Hertz 框架提供的一个用于生成代码的命令行工具，可以�
 - 通过指定已经定义好的 idl 文件进行代码生成，例如 `hz new -idl hello.thrift`。
 
     ```thrift
-    // idl/hello.thrift
+    // ./hello.thrift
     namespace go hello.example
     
     struct HelloReq {
@@ -178,7 +178,7 @@ curl http://127.0.0.1:8888/hello?name=bob
 如果需要对项目进行进一步的更新, 应使用 `hz update` 命令, 这里以添加一个 `ByeMethod` 方法为例。
 
 ```thrift
-// idl/hello.thrift
+// ./hello.thrift
 namespace go hello.example
 
 struct HelloReq {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

docs: Documentation only changes

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.



#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: `hz new -idl hello.thrift` indicates that the `hello.thrift` file is in the current directory, while the example code `idl\hello.thrift` shows that it's in `.\idl`. It's confusing!
zh(optional):  `hz new -idl hello.thrift` 表明 `hello.thrift` 在当前目录，但下面的代码示例中又有注释 `// idl/hello.thrift`，看起来很矛盾，所以改了代码注释。
