### PR TITLE
fix: update interrupt info type in ChatModelAgent configure CheckPoin…

### DIFF
--- a/content/zh/docs/eino/core_modules/eino_adk/agent_implementation/chat_model_agent.md
+++ b/content/zh/docs/eino/core_modules/eino_adk/agent_implementation/chat_model_agent.md
@@ -400,7 +400,7 @@ func main() {
           log.Fatal(event.Err)
        }
        if event.Action != nil && event.Action.Interrupted != nil {
-          fmt.Printf("\ninterrupt happened, info: %+v\n", event.Action.Interrupted.Data.(*compose.InterruptInfo).RerunNodesExtra["ToolNode"])
+          fmt.Printf("\ninterrupt happened, info: %+v\n", event.Action.Interrupted.Data.(*adk.ChatModelAgentInterruptInfo).Info.RerunNodesExtra["ToolNode"])
           continue
        }
        msg, err := event.Output.MessageOutput.GetMessage()


### PR DESCRIPTION
## bug: type assertion does not match
Interrupted != nil {
          fmt.Printf("\ninterrupt happened, info: %+v\n", event.Action.Interrupted.Data.(*compose.InterruptInfo).RerunNodesExtra["ToolNode"])
          continue
}

## fixed:
Interrupted != nil {
          fmt.Printf("\ninterrupt happened, info: %+v\n", event.Action.Interrupted.Data.(*adk.ChatModelAgentInterruptInfo).Info.RerunNodesExtra["ToolNode"])
          continue
}