### PR TITLE
docs(hertz): fix syntax error in example code

### DIFF
--- a/content/en/docs/hertz/tutorials/basic-feature/engine.md
+++ b/content/en/docs/hertz/tutorials/basic-feature/engine.md
@@ -314,7 +314,7 @@ Two methods are provided:
            }()
 
            go func() {
-               <-c..Finished()
+               <-c.Finished()
                fmt.Println("request process end")
            }()
        })
@@ -336,7 +336,7 @@ Two methods are provided:
            }()
 
            go func() {
-               <-c..Finished()
+               <-c.Finished()
                fmt.Println("request process end")
            }()
        })

--- a/content/zh/docs/hertz/tutorials/basic-feature/engine.md
+++ b/content/zh/docs/hertz/tutorials/basic-feature/engine.md
@@ -313,7 +313,7 @@ Hertz Server 支持流式写入响应。
            }()
 
            go func() {
-               <-c..Finished()
+               <-c.Finished()
                fmt.Println("request process end")
            }()
        })
@@ -335,7 +335,7 @@ Hertz Server 支持流式写入响应。
            }()
 
            go func() {
-               <-c..Finished()
+               <-c.Finished()
                fmt.Println("request process end")
            }()
        })


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

docs: Documentation only changes

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


Fix syntax error
```
c..Finished() -> c.Finished()
```
