### PR TITLE
fix: wrong ttstream doc paths in kitex release doc

### DIFF
--- a/content/en/blog/releases/Kitex/release-v0_15_1.md
+++ b/content/en/blog/releases/Kitex/release-v0_15_1.md
@@ -29,13 +29,13 @@ description: >
 4. **TTHeader Streaming: Support for ctx Cancel to Control Flow Lifecycle**
 
    - Quickly terminate streaming calls, saving model resources
-   - Aligns with gRPC, for detailed usage see [Stream Lifecycle Control Best Practices](/docs/kitex/tutorials/basic-feature/streamx/StreamX_Lifecycle_Control)
+   - Aligns with gRPC, for detailed usage see [Stream Lifecycle Control Best Practices](/docs/kitex/tutorials/basic-feature/streamx/streamx_lifecycle_control)
    - Supports Client actively invoking cancel to end streaming calls
    - Supports Client sensing the ctx cancel signal of the current Handler and cascading to end streaming calls
 
 5. **Streaming Error Handling Optimization**
 
-   - Quickly address specific error scenarios, accelerate troubleshooting of cascade cancel link issues, see [Stream Error Handling Best Practices](/docs/kitex/tutorials/basic-feature/streamx/StreamX_Error_Handling) for details
+   - Quickly address specific error scenarios, accelerate troubleshooting of cascade cancel link issues, see [Stream Error Handling Best Practices](/docs/kitex/tutorials/basic-feature/streamx/streamx_error_handling) for details
    - In cascade cancel scenarios, error description includes complete cancel link, quickly locating the first-hop service that actively cancels
    - Error description includes specific error scenarios and corresponding unique error codes
    - Unified and convenient cancel error handling method, eliminating the need for cumbersome string matching


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
