### PR TITLE
style: Optimize the user reading experience

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -71,6 +71,7 @@
         }
 
         &.active {
+            color: blue;
             font-weight: $font-weight-bold;
         }
     }


### PR DESCRIPTION
#### What type of PR is this?

style

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.

通过用蓝色突出显示所选页面的导航栏来优化用户阅读体验。

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:Optimize the user reading experience by highlighting the selected page’s navigation bar in blue.
zh: 通过用蓝色突出显示所选页面的导航栏来优化用户阅读体验。


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Why ?

新用户在阅读的时候，发现导航栏仅做相关标题的加粗（这会和相关标题进行混淆），导致新用户后边找不到自己看的文档的层次结构。因而才有了本次修改，目标是让新用户快速定位自己阅读文档的层次结构。

##### bad example

<img width="1604" height="1444" alt="image" src="https://github.com/user-attachments/assets/982a17cb-f782-45d9-b58b-444456f1c9eb" />

##### good example

<img width="2176" height="1546" alt="image" src="https://github.com/user-attachments/assets/91a9677d-2885-422f-8d5d-88e881f21c22" />









none
